### PR TITLE
refactor the symmetric class to de-couple dek generation from encrypt method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.1.1)
+    porky_lib (0.1.2)
       aws-sdk-kms
       msgpack
       rbnacl-libsodium

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ To encrypt data:
 ```ruby
 # Where data is the data to encrypt
 # cmk_key_id is the AWS key ID, Amazon Resource Name (ARN) or alias for the CMK to use to generate the data encryption key (DEK)
+# ciphertext_dek is an optional parameter to specify the data encryption key to use to encrypt the data. If not provided, a new data encryption key will be generated. Default is nil.
 # encryption_context is an optional parameter to provide additional authentication data for encrypting the DEK. Default is nil.
-[ciphertext_dek, ciphertext, nonce] = PorkyLib::Symmetric.instance.encrypt(data, cmk_key_id, encryption_context)
+[ciphertext_dek, ciphertext, nonce] = PorkyLib::Symmetric.instance.encrypt(data, cmk_key_id, ciphertext_dek, encryption_context)
 ```
 
 ### Decrypting Data
@@ -83,6 +84,22 @@ To decrypt data:
 # nonce is the nonce value associated with ciphertext
 # encryption_context is an optional parameter to provide additional authentication data for decrypting the DEK. Default is nil. Note, this must match the value that was used to encrypt.
 plaintext_data = PorkyLib::Symmetric.instance.decrypt(ciphertext_dek, ciphertext, nonce, encryption_context)
+```
+
+### Generating Data Encryption Keys
+To generate a new data encryption key:
+```ruby
+# Where cmk_key_id is the AWS key ID, Amazon Resource Name (ARN) or alias for the CMK to use to generate the data encryption key (DEK)
+# encryption_context is an optional parameter to provide additional authentication data for encrypting the DEK. Default is nil.
+plaintext_key, ciphertext_key = PorkyLib::Symmetric.instance.generate_data_encryption_key(cmk_key_id, encryption_context)
+```
+
+### Decrypting Data Encryption Keys
+To decrypt an existing ciphertext data encryption key:
+```ruby
+# Where ciphertext_key is the data encryption key, encrypted by a CMK within your AWS environment.
+# encryption_context is an optional parameter to provide additional authentication data for encrypting the DEK. Default is nil.
+plaintext_key = PorkyLib::Symmetric.instance.generate_data_encryption_key(ciphertext_key, encryption_context)
 ```
 
 ## Development

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/porky_lib/symmetric_spec.rb
+++ b/spec/porky_lib/symmetric_spec.rb
@@ -36,15 +36,36 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
       encryptionContextKey: 'bad encryption context'
     }
   end
+  let(:data_encryption_key_length) { 256 / 8 } # 256-bit key in bytes
 
   before do
     PorkyLib::Config.configure(default_config)
     PorkyLib::Config.initialize_aws
   end
 
+  it 'Generate data encryption key returns non-null values for plaintext_key and ciphertext_key' do
+    plaintext_key, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
+    expect(plaintext_key).not_to be nil
+    expect(ciphertext_key).not_to be nil
+  end
+
+  it 'Generate data encryption key with bad CMK key ID raises NotFoundException' do
+    expect do
+      symmetric.generate_data_encryption_key(bad_key_id, default_encryption_context)
+    end.to raise_error(Aws::KMS::Errors::NotFoundException)
+  end
+
   it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     expect(key).not_to be nil
+    expect(data).not_to be nil
+    expect(nonce).not_to be nil
+  end
+
+  it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce with existing data encryption key' do
+    _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
+    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, ciphertext_key, default_encryption_context)
+    expect(key).to eq(ciphertext_key)
     expect(data).not_to be nil
     expect(nonce).not_to be nil
   end
@@ -58,12 +79,12 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
 
   it 'Encrypt with bad CMK key ID raises NotFoundException' do
     expect do
-      symmetric.encrypt(plaintext_data, bad_key_id, default_encryption_context)
+      symmetric.encrypt(plaintext_data, bad_key_id, nil, default_encryption_context)
     end.to raise_error(Aws::KMS::Errors::NotFoundException)
   end
 
   it 'Decrypt returns an expected value' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     result = symmetric.decrypt(key, data, nonce, default_encryption_context)
     expect(result).to eq(plaintext_data)
   end
@@ -75,28 +96,28 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
   end
 
   it 'Decrypt with bad nonce raises CryptoError' do
-    key, data, = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, data, = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     expect do
       symmetric.decrypt(key, data, SecureRandom.hex(12), default_encryption_context)
     end.to raise_error(RbNaCl::CryptoError)
   end
 
   it 'Decrypt with bad encryption context raises InvalidCiphertextException' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     expect do
       symmetric.decrypt(key, data, nonce, bad_encryption_context)
     end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
   end
 
   it 'Decrypt with bad ciphertext data raises CryptoError' do
-    key, _, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, _, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     expect do
       symmetric.decrypt(key, SecureRandom.base64(32), nonce, default_encryption_context)
     end.to raise_error(RbNaCl::CryptoError)
   end
 
   it 'Decrypt with slightly modified data raises CryptoError' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     data_bytes = data.unpack('c*')
     data_bytes[0] = data_bytes[0] + 1
     data = data_bytes.pack('c*')
@@ -106,7 +127,7 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
   end
 
   it 'Decrypt with bad ciphertext key raises InvalidCiphertextException' do
-    _, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, default_encryption_context)
+    _, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
     expect do
       symmetric.decrypt(SecureRandom.base64(32), data, nonce, default_encryption_context)
     end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
@@ -145,6 +166,12 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
     expect do
       symmetric.enable_key_rotation(bad_key_id)
     end.to raise_error(Aws::KMS::Errors::NotFoundException)
+  end
+
+  it 'Securely deleting plaintext key returns a string of null characters matching the length of the key' do
+    plaintext_key, = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
+    plaintext_key = symmetric.secure_delete_plaintext_key(plaintext_key.bytesize)
+    expect(plaintext_key).to eq("\0" * data_encryption_key_length)
   end
 
   it 'Using mock client in test environment' do


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/porky/issues/16

*Why?*

There is a requirement in the issue above to have a secure delete API call, and to simplify integration with the attr_encrypted library, the generate_data_encryption_key and decrypt_data_encryption_key functions have been split out into separate APIs.

*How?*

Refactor code and update unit tests and README.

*Risks*

Low, porky_lib is not yet being used and this will make the library more flexible.

*Requested Reviewers*

@bcarr092 @bvrooman @nelobaba 