### PR TITLE
remove require statement that should be optional

### DIFF
--- a/lib/porky_lib.rb
+++ b/lib/porky_lib.rb
@@ -5,5 +5,4 @@ module PorkyLib
   require 'porky_lib/file_service'
   require 'porky_lib/symmetric'
   require 'porky_lib/version'
-  require 'porky_lib/aws/kms/client'
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

Do not require the bundled mock AWS client in the main library file.

*How?*

Remove require statement that was added accidentally.

*Risks*

N/A, fixes a bug

*Requested Reviewers*

@bcarr092 @bvrooman 
