### PR TITLE
Add support for specifying directories wihtin S3 buckets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.2.1)
+    porky_lib (0.2.2)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -29,7 +29,7 @@ class PorkyLib::FileService
     raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if file_size_invalid?(file)
 
     data = file_data(file)
-    file_key = SecureRandom.uuid
+    file_key = options.key?(:directory) ? "#{options[:directory]}/#{SecureRandom.uuid}" : SecureRandom.uuid
     tempfile = encrypt_file_contents(data, key_id, file_key)
 
     begin

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe PorkyLib::FileService, type: :request do
     expect(file_key).not_to be_nil
   end
 
+  it 'write encrypted data to S3 with directory' do
+    file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: '/directory1/dirA')
+    expect(file_key).not_to be_nil
+  end
+
   it 'write file to S3' do
     file_key = file_service.write(write_test_file(plaintext_data).path, bucket_name, default_key_id)
     expect(file_key).not_to be_nil
@@ -104,6 +109,15 @@ RSpec.describe PorkyLib::FileService, type: :request do
 
   it 'read encrypted data from S3' do
     file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+
+    plaintext = file_service.read(bucket_name, file_key)
+    expect(plaintext_data).to eq(plaintext)
+  end
+
+  it 'read encrypted data from S3 with directory' do
+    dir_name = 'directory1/dirA'
+    file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: dir_name)
+    expect(file_key).to include(dir_name)
 
     plaintext = file_service.read(bucket_name, file_key)
     expect(plaintext_data).to eq(plaintext)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

To allow for specifying a directory or directories within the S3 bucket that the file should be uploaded to.

*How?*

Prefix the filename with the desired directory structure if present.

*Risks*

Low

*Requested Reviewers*

@bcarr092 @dragoszt 
