### PR TITLE
feat: Add codeowners file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# For help consult: https://help.github.com/articles/about-codeowners/
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @Zetatango/security
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+# docs/*  docs@example.com


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Addresses https://github.com/Zetatango/zetatango/issues/2621

*Why?*

We need to define security code owners for sensitive parts of the code base

*How?*

Add a CODEOWNERS file to each repos

*Risks*

None

*Requested Reviewers*

@gregfletch and @nelobaba please review
