### PR TITLE
Fix bug in zeroing out plaintext key too early

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,8 @@ PATH
       aws-sdk-kms
       aws-sdk-s3
       msgpack
-      rbnacl
+      rbnacl (= 5.0.0)
+      rbnacl-libsodium
 
 GEM
   remote: https://rubygems.org/
@@ -47,8 +48,10 @@ GEM
     powerpack (0.1.2)
     rainbow (3.0.0)
     rake (12.3.1)
-    rbnacl (6.0.0)
+    rbnacl (5.0.0)
       ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,28 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.2.2)
+    porky_lib (0.3.0)
       aws-sdk-kms
       aws-sdk-s3
       msgpack
-      rbnacl-libsodium
+      rbnacl
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.104.0)
-    aws-sdk-core (3.27.0)
+    aws-partitions (1.115.0)
+    aws-sdk-core (3.39.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.9.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-kms (1.12.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.20.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-s3 (1.25.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
@@ -42,15 +42,13 @@ GEM
     json (2.1.0)
     msgpack (1.2.4)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
     rake (12.3.1)
-    rbnacl (5.0.0)
+    rbnacl (6.0.0)
       ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -68,14 +66,14 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.59.1)
+    rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
     rubocop_runner (2.1.0)
@@ -111,4 +109,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Zetatango/porky_lib.svg?style=svg&circle-token=f1a41896097b814585e5042a8e38425b4d1cdc0b)](https://circleci.com/gh/Zetatango/porky_lib) [![codecov](https://codecov.io/gh/Zetatango/porky_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/porky_lib)
+[![CircleCI](https://circleci.com/gh/Zetatango/porky_lib.svg?style=svg&circle-token=f1a41896097b814585e5042a8e38425b4d1cdc0b)](https://circleci.com/gh/Zetatango/porky_lib) [![codecov](https://codecov.io/gh/Zetatango/porky_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/porky_lib) [![Gem Version](https://badge.fury.io/rb/porky_lib.svg)](https://badge.fury.io/rb/porky_lib)
 
 # PorkyLib
 

--- a/lib/porky_lib/symmetric.rb
+++ b/lib/porky_lib/symmetric.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'aws-sdk-kms'
-require 'rbnacl'
+require 'rbnacl/libsodium'
 require 'singleton'
 
 class PorkyLib::Symmetric

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/porky_lib.gemspec
+++ b/porky_lib.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-kms'
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'msgpack'
-  spec.add_dependency 'rbnacl'
+  spec.add_dependency 'rbnacl', '=5.0.0'
+  spec.add_dependency 'rbnacl-libsodium'
 end

--- a/porky_lib.gemspec
+++ b/porky_lib.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-kms'
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'msgpack'
-  spec.add_dependency 'rbnacl-libsodium'
+  spec.add_dependency 'rbnacl'
 end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
   it 'read encrypted data from S3' do
     file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
 
-    plaintext = file_service.read(bucket_name, file_key)
+    plaintext, = file_service.read(bucket_name, file_key)
     expect(plaintext_data).to eq(plaintext)
   end
 
@@ -119,7 +119,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: dir_name)
     expect(file_key).to include(dir_name)
 
-    plaintext = file_service.read(bucket_name, file_key)
+    plaintext, = file_service.read(bucket_name, file_key)
     expect(plaintext_data).to eq(plaintext)
   end
 
@@ -127,7 +127,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     stub_large_file
     file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
 
-    plaintext = file_service.read(bucket_name, file_key)
+    plaintext, = file_service.read(bucket_name, file_key)
     expect(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).to eq(plaintext)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ end
 require 'bundler/setup'
 require 'byebug'
 require 'logger'
+require 'msgpack'
 require 'porky_lib'
 
 PorkyLib::Config.configure(aws_client_mock: true)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

There was an issue with the Analytics environment not being able to decrypt data retrieved from S3. This was caused by securely deleting the plaintext key value from memory too early.

*How?*

Fix the error and and return a new flag with the decrypted value indicating whether the data should be re-encrypted or not. This flag will be used to re-encrypt data retrieved from S3; DB attributes, however, will be re-encrypted by a data migration.

*Risks*

Until data is re-encrypted, security is weakened for those data objects affected.

*Requested Reviewers*

@bcarr092 @nelobaba 
