### PR TITLE
Add ability to overwrite existing files in S3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.3.0)
+    porky_lib (0.3.1)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -45,6 +45,7 @@ class PorkyLib::FileService
 
   def overwrite_file(file, file_key, bucket_name, key_id, options = {})
     raise FileServiceError, 'Invalid input. One or more input values is nil' if input_invalid?(file, bucket_name, key_id)
+    raise FileServiceError, 'Invalid input. file_key cannot be nil if overwriting an existing file' if file_key.nil?
     raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if file_size_invalid?(file)
 
     data = file_data(file)

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -43,6 +43,23 @@ class PorkyLib::FileService
     file_key
   end
 
+  def overwrite_file(file, file_key, bucket_name, key_id, options = {})
+    raise FileServiceError, 'Invalid input. One or more input values is nil' if input_invalid?(file, bucket_name, key_id)
+    raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if file_size_invalid?(file)
+
+    data = file_data(file)
+    tempfile = encrypt_file_contents(data, key_id, file_key)
+
+    begin
+      perform_upload(bucket_name, file_key, tempfile, options)
+    rescue Aws::Errors::ServiceError => e
+      raise FileServiceError, "Attempt to upload a file to S3 failed.\n#{e.message}"
+    end
+
+    # Remove tempfile from disk
+    tempfile.unlink
+  end
+
   private
 
   def input_invalid?(file, bucket_name, key_id)

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -238,4 +238,10 @@ RSpec.describe PorkyLib::FileService, type: :request do
       file_service.read(bucket_name, default_key_id)
     end.to raise_exception(PorkyLib::FileService::FileServiceError)
   end
+
+  it 'attempt to overwrite an existing file with nil file_key raise FileServiceError' do
+    expect do
+      file_service.overwrite_file(plaintext_data, nil, bucket_name, default_key_id)
+    end.to raise_error(PorkyLib::FileService::FileServiceError)
+  end
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

We need to be able to re-encrypt and overwrite existing documents that have been uploaded to S3.

*How?*

Add new method to the FileService which allows a calling service to overwrite an existing file in S3.

*Risks*

Low

*Requested Reviewers*

@nelobaba @bcarr092 
