### PR TITLE
Include file metadata in encrypted file before uploading to S3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.3.1)
+    porky_lib (0.3.2)
       aws-sdk-kms
       aws-sdk-s3
       msgpack
@@ -13,16 +13,16 @@ GEM
   specs:
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.115.0)
-    aws-sdk-core (3.39.0)
+    aws-partitions (1.117.0)
+    aws-sdk-core (3.40.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.12.0)
+    aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.25.0)
+    aws-sdk-s3 (1.27.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -77,8 +77,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
-    rubocop-rspec (1.29.1)
-      rubocop (>= 0.58.0)
+    rubocop-rspec (1.30.1)
+      rubocop (>= 0.60.0)
     rubocop_runner (2.1.0)
     ruby-progressbar (1.10.0)
     simplecov (0.16.1)

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

To simplify life for the ETL pipeline processing the encrypted files.

*How?*

Pass the options hash to the `encrypt_file_contents` method and include the plaintext metadata (if present in the options hash) in the file_contents.

*Risks*

Low, this will only apply to new files uploaded to S3 or existing if overwritten due to crypto bug.

*Requested Reviewers*

@bcarr092 @bvrooman @naveencotha-zt 
