### PR TITLE
Update dependencies so depfu can see all dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,15 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.4.0)
-      aws-sdk-kms
-      aws-sdk-s3
-      msgpack
-      rbnacl (= 5.0.0)
-      rbnacl-libsodium
+    porky_lib (0.4.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.124.0)
-    aws-sdk-core (3.44.0)
+    aws-partitions (1.127.0)
+    aws-sdk-core (3.44.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -95,12 +90,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-kms
+  aws-sdk-s3
   bundler
   bundler-audit
   byebug
   codecov
+  msgpack
   porky_lib!
   rake
+  rbnacl (= 5.0.0)
+  rbnacl-libsodium
   rspec
   rspec-collection_matchers
   rspec-mocks

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Zetatango/porky_lib.svg?style=svg&circle-token=f1a41896097b814585e5042a8e38425b4d1cdc0b)](https://circleci.com/gh/Zetatango/porky_lib) [![codecov](https://codecov.io/gh/Zetatango/porky_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/porky_lib) [![Gem Version](https://badge.fury.io/rb/porky_lib.svg)](https://badge.fury.io/rb/porky_lib)
+[![CircleCI](https://circleci.com/gh/Zetatango/porky_lib.svg?style=svg&circle-token=f1a41896097b814585e5042a8e38425b4d1cdc0b)](https://circleci.com/gh/Zetatango/porky_lib) [![codecov](https://codecov.io/gh/Zetatango/porky_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/porky_lib) [![Gem Version](https://badge.fury.io/rb/porky_lib.svg)](https://badge.fury.io/rb/porky_lib) [![Depfu](https://badges.depfu.com/badges/cbee343c363b7101657c0fc4bd5f551f/overview.svg)](https://depfu.com/github/Zetatango/porky_lib?project_id=6632)
 
 # PorkyLib
 

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/porky_lib.gemspec
+++ b/porky_lib.gemspec
@@ -20,11 +20,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'aws-sdk-kms'
+  spec.add_development_dependency 'aws-sdk-s3'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'codecov'
+  spec.add_development_dependency 'msgpack'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rbnacl', '=5.0.0'
+  spec.add_development_dependency 'rbnacl-libsodium'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-collection_matchers'
   spec.add_development_dependency 'rspec-mocks'
@@ -34,10 +39,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop_runner'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'timecop'
-
-  spec.add_dependency 'aws-sdk-kms'
-  spec.add_dependency 'aws-sdk-s3'
-  spec.add_dependency 'msgpack'
-  spec.add_dependency 'rbnacl', '=5.0.0'
-  spec.add_dependency 'rbnacl-libsodium'
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

Depfu was not able to see some of Porky Lib's dependencies. We want all of the dependencies to be visible to ensure that depfu keeps the project up to date.

*How?*

Move the dependencies in the gemspec file so they will be visible and add a dependencies badge from depfu to the README file.

*Risks*

Low.

*Requested Reviewers*

@bcarr092 @nelobaba 
