### PR TITLE
Add method for listing bucket objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - node_modules/**/*
     - output/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.3.7
+  TargetRubyVersion: 2.5.3
   RSpec:
     Patterns:
       - _spec.rb
@@ -34,7 +34,7 @@ Metrics/MethodLength:
   Max: 50
 
 Style/StringLiterals:
-  Enabled: false
+  Enabled: true
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 ruby '2.5.3'
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.4.2)
+    porky_lib (0.5.0)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     jaro_winkler (1.5.1)
     jmespath (1.4.0)
     json (2.1.0)
-    msgpack (1.2.4)
+    msgpack (1.2.6)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ file_data = PorkyLib::FileService.read(bucket_name, file_key)
 file_key = PorkyLib::FileService.write(file, bucket_name, key_id, options)
 ```
 
+### To List Objects in an S3 bucket
+```ruby
+# Where bucket_name is the name of the S3 bucket to list from
+# prefix is an optional parameter to limit the objects returned to be only those objects whose file key starts with prefix. For example, this could be a directory name.
+bucket_contents = PorkyLib::FileService.list(bucket_name, prefix)
+``` 
+
 ## Development
 
 Development on this project should occur on separate feature branches and pull requests should be submitted. When submitting a

--- a/lib/porky_lib/aws/kms/client.rb
+++ b/lib/porky_lib/aws/kms/client.rb
@@ -47,12 +47,12 @@ class Aws::KMS::Client
         {
           alias_arn: 'arn:aws:kms:us-east-2:111122223333:alias/example1',
           alias_name: 'alias/example1',
-          target_key_id: "4da1e216-62d0-46c5-a7c0-5f3a3d2f8046"
+          target_key_id: '4da1e216-62d0-46c5-a7c0-5f3a3d2f8046'
         },
         {
           alias_arn: 'arn:aws:kms:us-east-2:444455556666:alias/new_key',
           alias_name: 'alias/new_key',
-          target_key_id: "4da1e216-62d0-46c5-a7c0-5f3a3d2f8046"
+          target_key_id: '4da1e216-62d0-46c5-a7c0-5f3a3d2f8046'
         }
       ]
     }

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -61,6 +61,14 @@ class PorkyLib::FileService
     tempfile.unlink
   end
 
+  def list(bucket_name, prefix = nil)
+    raise FileServiceError, "Invalid input. 'bucket_name cannot be nil'" if bucket_name.nil?
+
+    s3.client.list_objects_v2(list_params(bucket_name, prefix)).to_h
+  rescue Aws::Errors::ServiceError => e
+    raise FileServiceError, "Attempt to list objects in bucket #{bucket_name} failed.\n#{e.message}"
+  end
+
   private
 
   def input_invalid?(file, bucket_name, key_id)
@@ -139,6 +147,12 @@ class PorkyLib::FileService
     tempfile.close
 
     tempfile
+  end
+
+  def list_params(bucket_name, prefix)
+    return { bucket: bucket_name } if prefix.nil?
+
+    { bucket: bucket_name, prefix: prefix }
   end
 
   def s3

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.4.2"
+  VERSION = '0.5.0'
 end

--- a/porky_lib.gemspec
+++ b/porky_lib.gemspec
@@ -5,10 +5,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'porky_lib/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "porky_lib"
+  spec.name          = 'porky_lib'
   spec.version       = PorkyLib::VERSION
-  spec.authors       = ["Greg Fletcher"]
-  spec.email         = ["greg.fletcher@zetatango.com"]
+  spec.authors       = ['Greg Fletcher']
+  spec.email         = ['greg.fletcher@zetatango.com']
 
   spec.summary       = 'A library for cryptographic services using AWS KMS and RbNaCl'
   spec.homepage      = 'https://github.com/Zetatango/porky_lib'

--- a/spec/porky_lib/config_spec.rb
+++ b/spec/porky_lib/config_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PorkyLib::Config, type: :request do
     PorkyLib::Config.configure(default_config)
   end
 
-  it "logger set directly is not nil" do
+  it 'logger set directly is not nil' do
     PorkyLib::Config.logger = Logger.new(STDOUT)
     expect(PorkyLib::Config.logger).not_to be nil
     expect(PorkyLib::Config.logger).to be_a(Logger)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

*Why?*

Dean requested the ability to be able to list objects within an S3 bucket.

*How?*

Add a `list` method that wraps the AWS SDK `list_obects_v2` method.

And update rubocop config to ensure string literals are consistent.

*Risks*

Low, new method

*Requested Reviewers*

@bcarr092 @deankeo 
