### PR TITLE
Reduce parallelism to 1 to free up build containers since we are not using parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    parallelism: 2
+    parallelism: 1
     working_directory: ~/porky_lib
     environment:
       - CODECOV_TOKEN: 4d03ca51-5054-4858-87c7-b37c376ffb6a


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

*Why?*

We are not currently taking advantage of CircleCI's parallelism but the config file is specifying parallelism of 2 meaning for every build we are performing each build step twice, which is unnecessarily taking up an extra build container on CircleCI leaving other build jobs to sit waiting for longer than necessary.

*How?*

Reduce parallelism until it is needed.

*How did this defect occur?*

Misunderstanding of the parallelism feature in CircleCI.

*Risks*

N/A

*Requested Reviewers*

@dragoszt @deankeo @kirksmithzt