### PR TITLE
Add read_raw_file and presigned_post

### DIFF
--- a/lib/porky_lib/config.rb
+++ b/lib/porky_lib/config.rb
@@ -6,7 +6,7 @@ class PorkyLib::Config
   @aws_key_secret = ''
   @aws_client_mock = false
   @max_file_size = 0
-  @presign_url_expires_in = 60*5 
+  @presign_url_expires_in = 300 # 5 minutes
 
   @config = {
     aws_region: @aws_region,

--- a/lib/porky_lib/config.rb
+++ b/lib/porky_lib/config.rb
@@ -6,13 +6,15 @@ class PorkyLib::Config
   @aws_key_secret = ''
   @aws_client_mock = false
   @max_file_size = 0
+  @presign_url_expires_in = 60*5 
 
   @config = {
     aws_region: @aws_region,
     aws_key_id: @aws_key_id,
     aws_key_secret: @aws_key_secret,
     aws_client_mock: @aws_client_mock,
-    max_file_size: @max_file_size
+    max_file_size: @max_file_size,
+    presign_url_expires_in: @presign_url_expires_in
   }
 
   @allowed_config_keys = @config.keys

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -91,6 +91,16 @@ class PorkyLib::FileService
     tempfile.unlink
   end
 
+  def presigned_post(bucket_name, file_key)
+    bucket = s3.bucket(bucket_name)
+    post = bucket.presigned_post(
+      key: file_key
+    )
+    [post.url, post.fields]
+  rescue Aws::Errors::ServiceError => e
+    raise FileServiceError, "PresignedPost for #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
+  end
+
   private
 
   def input_invalid?(file, bucket_name, key_id)

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -94,13 +94,21 @@ class PorkyLib::FileService
   def presigned_post_url(bucket_name, file_name, expires_in, ssekms_key_id, options = {})
     obj = s3.bucket(bucket_name).object(file_name)
 
-    obj.presigned_url(:put, #acl: "private",
+    obj.presigned_url(:put,
                       server_side_encryption: 'aws:kms',
                       ssekms_key_id: ssekms_key_id,
                       metadata: options[:metadata],
                       expires_in: expires_in)
   rescue Aws::Errors::ServiceError => e
-    raise FileServiceError, "PresignedPost for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
+    raise FileServiceError, "PresignedPostUrl for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
+  end
+
+  def presigned_get_url(bucket_name, file_key)
+    obj = s3.bucket(bucket_name).object(file_key)
+
+    obj.presigned_url(:get)
+  rescue Aws::Errors::ServiceError => e
+    raise FileServiceError, "PresignedGetUrl for #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
   end
 
   private

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -39,17 +39,17 @@ class PorkyLib::FileService
     raise FileServiceError, "File delete of #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
   end
 
-  def read_raw_file(bucket_name, file_key, options = {})
-    tempfile = read_file(bucket_name, file_key, options)
-    tempfile.open
-    raw_file = tempfile.read
-    tempfile.close
-
-    raw_file
-  end
-
   def read(bucket_name, file_key, options = {})
-    tempfile = read_file(bucket_name, file_key, options)
+    tempfile = Tempfile.new
+
+    begin
+      object = s3.bucket(bucket_name).object(file_key)
+      raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if object.content_length > max_size
+
+      object.download_file(tempfile.path, options)
+    rescue Aws::Errors::ServiceError => e
+      raise FileServiceError, "Attempt to download a file from S3 failed.\n#{e.message}"
+    end
 
     decrypt_file_contents(tempfile)
   end
@@ -177,21 +177,6 @@ class PorkyLib::FileService
     tempfile = Tempfile.new(file_key)
     tempfile << file_contents
     tempfile.close
-
-    tempfile
-  end
-
-  def read_file(bucket_name, file_key, options = {})
-    tempfile = Tempfile.new
-
-    begin
-      object = s3.bucket(bucket_name).object(file_key)
-      raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if object.content_length > max_size
-
-      object.download_file(tempfile.path, options)
-    rescue Aws::Errors::ServiceError => e
-      raise FileServiceError, "Attempt to download a file from S3 failed.\n#{e.message}"
-    end
 
     tempfile
   end

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -95,10 +95,11 @@ class PorkyLib::FileService
     file_name = options[:file_name] || SecureRandom.uuid
     obj = s3.bucket(bucket_name).object(file_name)
 
-    obj.presigned_url(:put,
-                      server_side_encryption: 'aws:kms',
-                      expires_in: presign_url_expires_in,
-                      metadata: options[:metadata])
+    presigned_url = obj.presigned_url(:put,
+                                      server_side_encryption: 'aws:kms',
+                                      expires_in: presign_url_expires_in,
+                                      metadata: options[:metadata])
+    [presigned_url, file_name]
   rescue Aws::Errors::ServiceError => e
     raise FileServiceError, "PresignedPostUrl for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
   end

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -91,14 +91,14 @@ class PorkyLib::FileService
     tempfile.unlink
   end
 
-  def presigned_post_url(bucket_name, file_name, expires_in, ssekms_key_id, options = {})
+  def presigned_post_url(bucket_name, options = {})
+    file_name = options[:file_name] || SecureRandom.uuid
     obj = s3.bucket(bucket_name).object(file_name)
 
     obj.presigned_url(:put,
                       server_side_encryption: 'aws:kms',
-                      ssekms_key_id: ssekms_key_id,
-                      metadata: options[:metadata],
-                      expires_in: expires_in)
+                      expires_in: presign_url_expires_in,
+                      metadata: options[:metadata])
   rescue Aws::Errors::ServiceError => e
     raise FileServiceError, "PresignedPostUrl for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
   end
@@ -106,7 +106,8 @@ class PorkyLib::FileService
   def presigned_get_url(bucket_name, file_key)
     obj = s3.bucket(bucket_name).object(file_key)
 
-    obj.presigned_url(:get)
+    obj.presigned_url(:get,
+                      expires_in: presign_url_expires_in)
   rescue Aws::Errors::ServiceError => e
     raise FileServiceError, "PresignedGetUrl for #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
   end
@@ -189,6 +190,10 @@ class PorkyLib::FileService
     tempfile.close
 
     tempfile
+  end
+
+  def presign_url_expires_in
+    PorkyLib::Config.config[:presign_url_expires_in]
   end
 
   def s3_client

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -91,14 +91,16 @@ class PorkyLib::FileService
     tempfile.unlink
   end
 
-  def presigned_post(bucket_name, file_key)
-    bucket = s3.bucket(bucket_name)
-    post = bucket.presigned_post(
-      key: file_key
-    )
-    [post.url, post.fields]
+  def presigned_post_url(bucket_name, file_name, expires_in, ssekms_key_id, options = {})
+    obj = s3.bucket(bucket_name).object(file_name)
+
+    obj.presigned_url(:put, #acl: "private",
+                      server_side_encryption: 'aws:kms',
+                      ssekms_key_id: ssekms_key_id,
+                      metadata: options[:metadata],
+                      expires_in: expires_in)
   rescue Aws::Errors::ServiceError => e
-    raise FileServiceError, "PresignedPost for #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
+    raise FileServiceError, "PresignedPost for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
   end
 
   private

--- a/spec/porky_lib/config_spec.rb
+++ b/spec/porky_lib/config_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe PorkyLib::Config, type: :request do
       aws_key_id: '',
       aws_key_secret: '',
       aws_client_mock: true,
-      max_file_size: 0 }
+      max_file_size: 0,
+      presign_url_expires_in: 300 }
   end
 
   before do

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     it 'returns presigned post url and fields' do
       url = file_service.presigned_post_url(bucket_name)
       uri = URI.parse(url)
-      query_params = CGI::parse(uri.query)
+      query_params = CGI.parse(uri.query)
 
       expect(uri.scheme).to eq('https')
       expect(uri.path).to include("/#{bucket_name}/")
@@ -425,17 +425,16 @@ RSpec.describe PorkyLib::FileService, type: :request do
     end
 
     it 'uses file_name as key if provided' do
-      url = file_service.presigned_post_url(bucket_name, {file_name: default_file_key})
+      url = file_service.presigned_post_url(bucket_name, file_name: default_file_key)
       uri = URI.parse(url)
-      query_params = CGI::parse(uri.query)
 
       expect(uri.path).to eq("/#{bucket_name}/#{default_file_key}")
     end
 
     it 'passes metadata if provided' do
-      url = file_service.presigned_post_url(bucket_name, {metadata: metadata})
+      url = file_service.presigned_post_url(bucket_name, metadata: metadata)
       uri = URI.parse(url)
-      query_params = CGI::parse(uri.query)
+      query_params = CGI.parse(uri.query)
 
       expect(uri.scheme).to eq('https')
       expect(query_params["x-amz-meta-report_type"]).to eq([metadata[:report_type]])
@@ -446,7 +445,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     it 'sets expiry date based on value defined in config' do
       url = file_service.presigned_post_url(bucket_name)
       uri = URI.parse(url)
-      query_params = CGI::parse(uri.query)
+      query_params = CGI.parse(uri.query)
 
       expect(query_params["X-Amz-Expires"]).to eq([PorkyLib::Config.config[:presign_url_expires_in].to_s])
     end
@@ -464,7 +463,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       allow(Aws::S3::Object).to receive(:new).and_return(s3_object)
       allow(s3_object).to receive(:presigned_url).and_raise(Aws::S3::Errors::ServiceError.new(nil, 'Error'))
       begin
-        file_service.presigned_post_url(bucket_name, {file_name: default_file_key})
+        file_service.presigned_post_url(bucket_name, file_name: default_file_key)
       rescue PorkyLib::FileService::FileServiceError => e
         expect(e.message).to match(/\APresignedPostUrl for #{default_file_key} from S3 bucket #{bucket_name} failed:\s+/)
       end
@@ -485,7 +484,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     it 'sets expiry date based on value defined in config' do
       url = file_service.presigned_get_url(bucket_name, default_file_key)
       uri = URI.parse(url)
-      query_params = CGI::parse(uri.query)
+      query_params = CGI.parse(uri.query)
 
       expect(query_params["X-Amz-Expires"]).to eq([PorkyLib::Config.config[:presign_url_expires_in].to_s])
     end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -414,16 +414,41 @@ RSpec.describe PorkyLib::FileService, type: :request do
     let(:s3_object) { instance_double(Aws::S3::Object) }
 
     it 'returns presigned post url and fields' do
-      url = file_service.presigned_post_url(bucket_name, default_file_key, 3600, default_key_id)
+      url = file_service.presigned_post_url(bucket_name)
       uri = URI.parse(url)
       query_params = CGI::parse(uri.query)
 
       expect(uri.scheme).to eq('https')
-      expect(uri.path).to eq("/#{bucket_name}/#{default_file_key}")
+      expect(uri.path).to include("/#{bucket_name}/")
 
       expect(query_params["x-amz-server-side-encryption"]).to eq(["aws:kms"])
-      expect(query_params["x-amz-server-side-encryption-aws-kms-key-id"]).to eq([default_key_id])
-      expect(query_params["X-Amz-Expires"]).to eq(["3600"])
+    end
+
+    it 'uses file_name as key if provided' do
+      url = file_service.presigned_post_url(bucket_name, {file_name: default_file_key})
+      uri = URI.parse(url)
+      query_params = CGI::parse(uri.query)
+
+      expect(uri.path).to eq("/#{bucket_name}/#{default_file_key}")
+    end
+
+    it 'passes metadata if provided' do
+      url = file_service.presigned_post_url(bucket_name, {metadata: metadata})
+      uri = URI.parse(url)
+      query_params = CGI::parse(uri.query)
+
+      expect(uri.scheme).to eq('https')
+      expect(query_params["x-amz-meta-report_type"]).to eq([metadata[:report_type]])
+      expect(query_params["x-amz-meta-report_date"]).to eq([metadata[:report_date]])
+      expect(query_params["x-amz-meta-extra_metadata"]).to eq([metadata[:extra_metadata]])
+    end
+
+    it 'sets expiry date based on value defined in config' do
+      url = file_service.presigned_post_url(bucket_name)
+      uri = URI.parse(url)
+      query_params = CGI::parse(uri.query)
+
+      expect(query_params["X-Amz-Expires"]).to eq([PorkyLib::Config.config[:presign_url_expires_in].to_s])
     end
 
     it 'raises a FileServiceError on S3 lib exception' do
@@ -431,7 +456,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       allow(s3_object).to receive(:presigned_url).and_raise(Aws::S3::Errors::ServiceError.new(nil, 'Error'))
 
       expect do
-        file_service.presigned_post_url(bucket_name, default_file_key, 3600, default_key_id)
+        file_service.presigned_post_url(bucket_name)
       end.to raise_error(PorkyLib::FileService::FileServiceError)
     end
 
@@ -439,7 +464,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       allow(Aws::S3::Object).to receive(:new).and_return(s3_object)
       allow(s3_object).to receive(:presigned_url).and_raise(Aws::S3::Errors::ServiceError.new(nil, 'Error'))
       begin
-        file_service.presigned_post_url(bucket_name, default_file_key, 3600, default_key_id)
+        file_service.presigned_post_url(bucket_name, {file_name: default_file_key})
       rescue PorkyLib::FileService::FileServiceError => e
         expect(e.message).to match(/\APresignedPostUrl for #{default_file_key} from S3 bucket #{bucket_name} failed:\s+/)
       end
@@ -455,6 +480,14 @@ RSpec.describe PorkyLib::FileService, type: :request do
 
       expect(uri.scheme).to eq('https')
       expect(uri.path).to eq("/#{bucket_name}/#{default_file_key}")
+    end
+
+    it 'sets expiry date based on value defined in config' do
+      url = file_service.presigned_get_url(bucket_name, default_file_key)
+      uri = URI.parse(url)
+      query_params = CGI::parse(uri.query)
+
+      expect(query_params["X-Amz-Expires"]).to eq([PorkyLib::Config.config[:presign_url_expires_in].to_s])
     end
 
     it 'raises a FileServiceError on S3 lib exception' do

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe PorkyLib::FileService, type: :request do
       extra_metadata: 'extra metadata info'
     }
   end
+  let(:ciphertext_data_large) { File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_ciphertext") }
+  let(:plaintext_data_large) { File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext") }
 
   before do
     PorkyLib::Config.configure(default_config)
@@ -71,17 +73,16 @@ RSpec.describe PorkyLib::FileService, type: :request do
     }
   end
 
-  def stub_large_file
+  def stub_large_file(large_file)
     Aws.config[:s3].delete(:stub_responses)
 
-    ciphertext_data_large = File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_ciphertext")
     Aws.config[:s3] = {
       stub_responses: {
         get_object: {
-          body: ciphertext_data_large
+          body: large_file
         },
         head_object: {
-          content_length: ciphertext_data_large.bytesize
+          content_length: large_file.bytesize
         }
       }
     }
@@ -94,227 +95,295 @@ RSpec.describe PorkyLib::FileService, type: :request do
     tempfile
   end
 
-  it 'write encrypted data to S3' do
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
-    expect(file_key).not_to be_nil
-  end
+  describe '#write' do
+    it 'write encrypted data to S3' do
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+      expect(file_key).not_to be_nil
+    end
 
-  it 'write large encrypted data to S3' do
-    file_key = file_service.write(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext"),
-                                  bucket_name, default_key_id)
-    expect(file_key).not_to be_nil
-  end
+    it 'write large encrypted data to S3' do
+      file_key = file_service.write(plaintext_data_large,
+                                    bucket_name, default_key_id)
+      expect(file_key).not_to be_nil
+    end
 
-  it 'write encrypted data to S3 with metadata' do
-    metadata = { content_type: 'test/data' }
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id, metadata: metadata)
-    expect(file_key).not_to be_nil
-  end
-
-  it 'write encrypted data to S3 with directory' do
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: '/directory1/dirA')
-    expect(file_key).not_to be_nil
-  end
-
-  it 'write file to S3' do
-    file_key = file_service.write(write_test_file(plaintext_data).path, bucket_name, default_key_id)
-    expect(file_key).not_to be_nil
-  end
-
-  it 'write large file to S3' do
-    PorkyLib::Config.configure(max_file_size: 10 * 1024)
-    expect do
-      file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).path,
-                         bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
-  end
-
-  it 'write file too large to S3' do
-    file_key = file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).path,
-                                  bucket_name, default_key_id)
-    expect(file_key).not_to be_nil
-  end
-
-  it 'write file to S3 with metadata' do
-    tempfile = write_test_file(plaintext_data)
-    metadata = { content_type: 'test/data' }
-    file_key = file_service.write(tempfile.path, bucket_name, default_key_id, metadata: metadata)
-    expect(file_key).not_to be_nil
-  end
-
-  it 'overwrite encrypted data to S3' do
-    expect do
-      file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id)
-    end.not_to raise_exception
-  end
-
-  it 'overwrite large encrypted data to S3' do
-    expect do
-      file_service.overwrite_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext"), default_file_key,
-                                  bucket_name, default_key_id)
-    end.not_to raise_exception
-  end
-
-  it 'overwrite encrypted data to S3 with metadata' do
-    expect do
+    it 'write encrypted data to S3 with metadata' do
       metadata = { content_type: 'test/data' }
-      file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id, metadata: metadata)
-    end.not_to raise_exception
-  end
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id, metadata: metadata)
+      expect(file_key).not_to be_nil
+    end
 
-  it 'overwrite file too large to S3' do
-    PorkyLib::Config.configure(max_file_size: 10 * 1024)
-    expect do
-      file_service.overwrite_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext"), default_file_key,
-                                  bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
-  end
+    it 'write encrypted data to S3 with directory' do
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: '/directory1/dirA')
+      expect(file_key).not_to be_nil
+    end
 
-  it 'read encrypted data from S3' do
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+    it 'write file to S3' do
+      file_key = file_service.write(write_test_file(plaintext_data).path, bucket_name, default_key_id)
+      expect(file_key).not_to be_nil
+    end
 
-    plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
-    expect(plaintext_data).to eq(plaintext)
-    expect(should_reencrypt).to be_falsey
-  end
+    it 'write large file to S3' do
+      PorkyLib::Config.configure(max_file_size: 10 * 1024)
+      expect do
+        file_service.write(write_test_file(plaintext_data_large).path,
+                           bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
+    end
 
-  it 'read encrypted data from S3 with directory' do
-    dir_name = 'directory1/dirA'
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: dir_name)
-    expect(file_key).to include(dir_name)
+    it 'write file too large to S3' do
+      file_key = file_service.write(write_test_file(plaintext_data_large).path,
+                                    bucket_name, default_key_id)
+      expect(file_key).not_to be_nil
+    end
 
-    plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
-    expect(plaintext_data).to eq(plaintext)
-    expect(should_reencrypt).to be_falsey
-  end
+    it 'write file to S3 with metadata' do
+      tempfile = write_test_file(plaintext_data)
+      metadata = { content_type: 'test/data' }
+      file_key = file_service.write(tempfile.path, bucket_name, default_key_id, metadata: metadata)
+      expect(file_key).not_to be_nil
+    end
 
-  it 'read encrypted data from S3 which should be re-encrypted' do
-    stub_data_to_be_reencrypted
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+    it 'attempt to write with file nil raises FileServiceError' do
+      expect do
+        file_service.write(nil, bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
 
-    plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
-    expect(plaintext_data).to eq(plaintext)
-    expect(should_reencrypt).to be_truthy
-  end
+    it 'attempt to write with bucket name nil raises FileServiceError' do
+      expect do
+        file_service.write(plaintext_data, nil, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
 
-  it 'read large encrypted data from S3' do
-    stub_large_file
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+    it 'attempt to write with key ID nil raises FileServiceError' do
+      expect do
+        file_service.write(plaintext_data, bucket_name, nil)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
 
-    plaintext, = file_service.read(bucket_name, file_key)
-    expect(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).to eq(plaintext)
-  end
-
-  it 'read encrypted data too large from S3' do
-    stub_large_file
-    file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
-
-    PorkyLib::Config.configure(max_file_size: 10 * 1024)
-    expect do
-      file_service.read(bucket_name, file_key)
-    end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
-  end
-
-  it 'file_contents contains associated metadata if provided' do
-    file_data = JSON.parse(ciphertext_data, symbolize_names: true)
-    file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], metadata: metadata)
-    expect(JSON.parse(file_contents, symbolize_names: true)[:metadata]).to eq(metadata)
-  end
-
-  it 'file_contents does not contain metadata field if none provided' do
-    file_data = JSON.parse(ciphertext_data, symbolize_names: true)
-    file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], {})
-    expect(JSON.parse(file_contents, symbolize_names: true)).not_to have_key(:metadata)
-  end
-
-  it 'file_contents does not contain metadata field if options is nil' do
-    file_data = JSON.parse(ciphertext_data, symbolize_names: true)
-    file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], nil)
-    expect(JSON.parse(file_contents, symbolize_names: true)).not_to have_key(:metadata)
-  end
-
-  it 'attempt to write with file nil raises FileServiceError' do
-    expect do
-      file_service.write(nil, bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
-  end
-
-  it 'attempt to write with bucket name nil raises FileServiceError' do
-    expect do
-      file_service.write(plaintext_data, nil, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
-  end
-
-  it 'attempt to write with key ID nil raises FileServiceError' do
-    expect do
-      file_service.write(plaintext_data, bucket_name, nil)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
-  end
-
-  it 'attempt to write to bucket without permission raises FileServiceError' do
-    Aws.config[:s3].delete(:stub_responses)
-    Aws.config[:s3] = {
-      stub_responses: {
-        put_object: 'Forbidden'
+    it 'attempt to write to bucket without permission raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          put_object: 'Forbidden'
+        }
       }
-    }
-    expect do
-      file_service.write(plaintext_data, bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
-  end
+      expect do
+        file_service.write(plaintext_data, bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
 
-  it 'attempt to overwrite to bucket without permission raises FileServiceError' do
-    Aws.config[:s3].delete(:stub_responses)
-    Aws.config[:s3] = {
-      stub_responses: {
-        put_object: 'Forbidden'
+    it 'attempt to write to bucket that does not exist raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          put_object: 'NotFound'
+        }
       }
-    }
-    expect do
-      file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
+      expect do
+        file_service.write(plaintext_data, bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
   end
 
-  it 'attempt to write to bucket that does not exist raises FileServiceError' do
-    Aws.config[:s3].delete(:stub_responses)
-    Aws.config[:s3] = {
-      stub_responses: {
-        put_object: 'NotFound'
+  describe '#overwrite_file' do
+    it 'overwrite encrypted data to S3' do
+      expect do
+        file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id)
+      end.not_to raise_exception
+    end
+
+    it 'overwrite large encrypted data to S3' do
+      expect do
+        file_service.overwrite_file(plaintext_data_large, default_file_key,
+                                    bucket_name, default_key_id)
+      end.not_to raise_exception
+    end
+
+    it 'overwrite encrypted data to S3 with metadata' do
+      expect do
+        metadata = { content_type: 'test/data' }
+        file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id, metadata: metadata)
+      end.not_to raise_exception
+    end
+
+    it 'overwrite file too large to S3' do
+      PorkyLib::Config.configure(max_file_size: 10 * 1024)
+      expect do
+        file_service.overwrite_file(plaintext_data_large, default_file_key,
+                                    bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
+    end
+
+    it 'attempt to overwrite to bucket without permission raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          put_object: 'Forbidden'
+        }
       }
-    }
-    expect do
-      file_service.write(plaintext_data, bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
+      expect do
+        file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
+
+    it 'attempt to overwrite an existing file with nil file_key raise FileServiceError' do
+      expect do
+        file_service.overwrite_file(plaintext_data, nil, bucket_name, default_key_id)
+      end.to raise_error(PorkyLib::FileService::FileServiceError)
+    end
   end
 
-  it 'attempt to read from bucket without permission raises FileServiceError' do
-    Aws.config[:s3].delete(:stub_responses)
-    Aws.config[:s3] = {
-      stub_responses: {
-        get_object: 'Forbidden'
+  describe '#read' do
+    it 'read encrypted data from S3' do
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+
+      plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
+      expect(plaintext_data).to eq(plaintext)
+      expect(should_reencrypt).to be_falsey
+    end
+
+    it 'read encrypted data from S3 with directory' do
+      dir_name = 'directory1/dirA'
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id, directory: dir_name)
+      expect(file_key).to include(dir_name)
+
+      plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
+      expect(plaintext_data).to eq(plaintext)
+      expect(should_reencrypt).to be_falsey
+    end
+
+    it 'read encrypted data from S3 which should be re-encrypted' do
+      stub_data_to_be_reencrypted
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+
+      plaintext, should_reencrypt = file_service.read(bucket_name, file_key)
+      expect(plaintext_data).to eq(plaintext)
+      expect(should_reencrypt).to be_truthy
+    end
+
+    it 'read large encrypted data from S3' do
+      stub_large_file(ciphertext_data_large)
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+
+      plaintext, = file_service.read(bucket_name, file_key)
+      expect(plaintext_data_large).to eq(plaintext)
+    end
+
+    it 'read encrypted data too large from S3' do
+      stub_large_file(ciphertext_data_large)
+      file_key = file_service.write(plaintext_data, bucket_name, default_key_id)
+
+      PorkyLib::Config.configure(max_file_size: 10 * 1024)
+      expect do
+        file_service.read(bucket_name, file_key)
+      end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
+    end
+
+    it 'attempt to read from bucket without permission raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          get_object: 'Forbidden'
+        }
       }
-    }
-    expect do
-      file_service.read(bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
-  end
+      expect do
+        file_service.read(bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
 
-  it 'attempt to read from bucket does not exist raises FileServiceError' do
-    Aws.config[:s3].delete(:stub_responses)
-    Aws.config[:s3] = {
-      stub_responses: {
-        get_object: 'NotFound'
+    it 'attempt to read from bucket does not exist raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          get_object: 'NotFound'
+        }
       }
-    }
-    expect do
-      file_service.read(bucket_name, default_key_id)
-    end.to raise_exception(PorkyLib::FileService::FileServiceError)
+      expect do
+        file_service.read(bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
   end
 
-  it 'attempt to overwrite an existing file with nil file_key raise FileServiceError' do
-    expect do
-      file_service.overwrite_file(plaintext_data, nil, bucket_name, default_key_id)
-    end.to raise_error(PorkyLib::FileService::FileServiceError)
+  describe '#read_raw_file' do
+    before do
+      Aws.config[:s3] = {
+        stub_responses: {
+          get_object: {
+            body: plaintext_data
+          }
+        }
+      }
+    end
+    it 'read un-encrypted data from S3' do
+      file_key = write_test_file(plaintext_data).path
+
+      plaintext = file_service.read_raw_file(bucket_name, file_key)
+      expect(plaintext_data).to eq(plaintext)
+    end
+
+    it 'read large un-encrypted data from S3' do
+      stub_large_file(plaintext_data_large)
+      file_key = write_test_file(plaintext_data).path
+
+      plaintext = file_service.read_raw_file(bucket_name, file_key)
+      expect(plaintext_data_large).to eq(plaintext)
+    end
+
+    it 'read un-encrypted data too large from S3' do
+      stub_large_file(plaintext_data_large)
+      file_key = write_test_file(plaintext_data).path
+
+      PorkyLib::Config.configure(max_file_size: 10 * 1024)
+      expect do
+        file_service.read_raw_file(bucket_name, file_key)
+      end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
+    end
+
+    it 'attempt to read from bucket without permission raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          get_object: 'Forbidden'
+        }
+      }
+      expect do
+        file_service.read_raw_file(bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
+
+    it 'attempt to read from bucket does not exist raises FileServiceError' do
+      Aws.config[:s3].delete(:stub_responses)
+      Aws.config[:s3] = {
+        stub_responses: {
+          get_object: 'NotFound'
+        }
+      }
+      expect do
+        file_service.read_raw_file(bucket_name, default_key_id)
+      end.to raise_exception(PorkyLib::FileService::FileServiceError)
+    end
+  end
+
+  describe '#file_contents' do
+    it 'file_contents contains associated metadata if provided' do
+      file_data = JSON.parse(ciphertext_data, symbolize_names: true)
+      file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], metadata: metadata)
+      expect(JSON.parse(file_contents, symbolize_names: true)[:metadata]).to eq(metadata)
+    end
+
+    it 'file_contents does not contain metadata field if none provided' do
+      file_data = JSON.parse(ciphertext_data, symbolize_names: true)
+      file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], {})
+      expect(JSON.parse(file_contents, symbolize_names: true)).not_to have_key(:metadata)
+    end
+
+    it 'file_contents does not contain metadata field if options is nil' do
+      file_data = JSON.parse(ciphertext_data, symbolize_names: true)
+      file_contents = file_service.send(:file_contents, file_data[:key], file_data[:data], file_data[:nonce], nil)
+      expect(JSON.parse(file_contents, symbolize_names: true)).not_to have_key(:metadata)
+    end
   end
 
   describe '#read_file_info' do

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -316,6 +316,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
         }
       }
     end
+
     it 'read un-encrypted data from S3' do
       file_key = write_test_file(plaintext_data).path
 
@@ -475,14 +476,9 @@ RSpec.describe PorkyLib::FileService, type: :request do
 
     it 'returns presigned post url and fields' do
       url, fields = file_service.presigned_post(bucket_name, default_file_key)
-      
+
       expect(url).to eq("https://s3.amazonaws.com/#{bucket_name}")
       expect(fields["key"]).to eq(default_file_key)
-      expect(fields["policy"]).not_to be_nil
-      expect(fields["x-amz-credential"]).not_to be_nil
-      expect(fields["x-amz-algorithm"]).not_to be_nil
-      expect(fields["x-amz-date"]).not_to be_nil
-      expect(fields["x-amz-signature"]).not_to be_nil
     end
 
     it 'raises a FileServiceError on S3 lib exception' do

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     let(:s3_object) { instance_double(Aws::S3::Object) }
 
     it 'returns presigned post url and fields' do
-      url = file_service.presigned_post_url(bucket_name)
+      url, _file_name = file_service.presigned_post_url(bucket_name)
       uri = URI.parse(url)
       query_params = CGI.parse(uri.query)
 
@@ -425,14 +425,15 @@ RSpec.describe PorkyLib::FileService, type: :request do
     end
 
     it 'uses file_name as key if provided' do
-      url = file_service.presigned_post_url(bucket_name, file_name: default_file_key)
+      url, file_name = file_service.presigned_post_url(bucket_name, file_name: default_file_key)
       uri = URI.parse(url)
 
       expect(uri.path).to eq("/#{bucket_name}/#{default_file_key}")
+      expect(default_file_key).to eq(file_name)
     end
 
     it 'passes metadata if provided' do
-      url = file_service.presigned_post_url(bucket_name, metadata: metadata)
+      url, _file_name = file_service.presigned_post_url(bucket_name, metadata: metadata)
       uri = URI.parse(url)
       query_params = CGI.parse(uri.query)
 
@@ -443,7 +444,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
     end
 
     it 'sets expiry date based on value defined in config' do
-      url = file_service.presigned_post_url(bucket_name)
+      url, _file_name = file_service.presigned_post_url(bucket_name)
       uri = URI.parse(url)
       query_params = CGI.parse(uri.query)
 


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/5523

*Why?*

Preparation for encryption performance issue proposal described in the issue ^

*How?*

Added capabilities to:
- generate presigned_post_url => this will be used to upload documents directly from the frontend client to s3.
- generate presigned_get_url => this will be used to get a url to download an object

Summary:
- `presign_url_expires_in` added to be configurable. Default to 5 minutes.
- `presigned_post_url` only receives bucket_name. If file_key is not provided, it generates a random one. Accepts metadata, and sets server side encryption with kms.
- `presigned_get_url` receives bucket name and object key. 

*Risks*

Explain the risks that are involved with making this change, if any.
