### PR TITLE
chore: Add benchmarking to encryption/decryption.

### DIFF
--- a/lib/porky_lib/symmetric.rb
+++ b/lib/porky_lib/symmetric.rb
@@ -62,25 +62,74 @@ class PorkyLib::Symmetric
     resp.plaintext
   end
 
-  def encrypt(data, cmk_key_id, ciphertext_dek = nil, encryption_context = nil, track_statistics = false)
+  def encrypt(data, cmk_key_id, ciphertext_dek = nil, encryption_context = nil)
+    return if data.nil? || cmk_key_id.nil?
+
+    # Generate a new data encryption key or decrypt existing key, if provided
+    plaintext_key = decrypt_data_encryption_key(ciphertext_dek, encryption_context) if ciphertext_dek
+    ciphertext_key = ciphertext_dek if ciphertext_dek
+    plaintext_key, ciphertext_key = generate_data_encryption_key(cmk_key_id, encryption_context) unless ciphertext_dek
+
+    # Initialize the box
+    secret_box = RbNaCl::SecretBox.new(plaintext_key)
+
+    # First, make a nonce: A single-use value never repeated under the same key
+    # The nonce isn't secret, and can be sent with the ciphertext.
+    # The cipher instance has a nonce_bytes method for determining how many bytes should be in a nonce
+    nonce = RbNaCl::Random.random_bytes(secret_box.nonce_bytes)
+
+    # Encrypt a message with SecretBox
+    ciphertext = secret_box.encrypt(nonce, data)
+
+    # Securely delete the plaintext value from memory
+    plaintext_key.replace(secure_delete_plaintext_key(plaintext_key.bytesize))
+
+    [ciphertext_key, ciphertext, nonce]
+  end
+
+  def decrypt(ciphertext_dek, ciphertext, nonce, encryption_context = nil)
+    return if ciphertext.nil? || ciphertext_dek.nil? || nonce.nil?
+
+    # Decrypt the data encryption key
+    plaintext_key = decrypt_data_encryption_key(ciphertext_dek, encryption_context)
+    secret_box = RbNaCl::SecretBox.new(plaintext_key)
+
+    should_reencrypt = false
+    begin
+      # Decrypt the message
+      message = secret_box.decrypt(nonce, ciphertext)
+    rescue RbNaCl::CryptoError
+      # For backwards compatibility due to a code error in a previous release
+      plaintext_key.replace(secure_delete_plaintext_key(plaintext_key.bytesize))
+      message = secret_box.decrypt(nonce, ciphertext)
+      should_reencrypt = true
+    end
+
+    # Securely delete the plaintext value from memory
+    plaintext_key.replace(secure_delete_plaintext_key(plaintext_key.bytesize))
+
+    [message, should_reencrypt]
+  end
+
+  def encrypt_with_benchmark(data, cmk_key_id, ciphertext_dek = nil, encryption_context = nil)
     return if data.nil? || cmk_key_id.nil?
 
     encryption_statistics = {}
 
     # Generate a new data encryption key or decrypt existing key, if provided
     if ciphertext_dek
-      plaintext_key = benchmark_block(track_statistics, encryption_statistics, :decrypt_key) do
+      plaintext_key = benchmark_block(encryption_statistics, :decrypt_key) do
         decrypt_data_encryption_key(ciphertext_dek, encryption_context)
       end
 
       ciphertext_key = ciphertext_dek
     else
-      plaintext_key, ciphertext_key = benchmark_block(track_statistics, encryption_statistics, :generate_key) do
+      plaintext_key, ciphertext_key = benchmark_block(encryption_statistics, :generate_key) do
         generate_data_encryption_key(cmk_key_id, encryption_context)
       end
     end
 
-    nonce, ciphertext = benchmark_block(track_statistics, encryption_statistics, :encrypt) do
+    nonce, ciphertext = benchmark_block(encryption_statistics, :encrypt) do
       # Initialize the box
       secret_box = RbNaCl::SecretBox.new(plaintext_key)
 
@@ -95,7 +144,7 @@ class PorkyLib::Symmetric
       [nonce, ciphertext]
     end
 
-    benchmark_block(track_statistics, encryption_statistics, :clear_key) do
+    benchmark_block(encryption_statistics, :clear_key) do
       # Securely delete the plaintext value from memory
       plaintext_key.replace(secure_delete_plaintext_key(plaintext_key.bytesize))
     end
@@ -103,17 +152,17 @@ class PorkyLib::Symmetric
     [ciphertext_key, ciphertext, nonce, encryption_statistics]
   end
 
-  def decrypt(ciphertext_dek, ciphertext, nonce, encryption_context = nil, track_statistics = false)
+  def decrypt_with_benchmark(ciphertext_dek, ciphertext, nonce, encryption_context = nil)
     return if ciphertext.nil? || ciphertext_dek.nil? || nonce.nil?
 
     encryption_statistics = {}
 
-    plaintext_key = benchmark_block(track_statistics, encryption_statistics, :decrypt_key) do
+    plaintext_key = benchmark_block(encryption_statistics, :decrypt_key) do
       # Decrypt the data encryption key
       decrypt_data_encryption_key(ciphertext_dek, encryption_context)
     end
 
-    message, should_reencrypt = benchmark_block(track_statistics, encryption_statistics, :decrypt) do
+    message, should_reencrypt = benchmark_block(encryption_statistics, :decrypt) do
       secret_box = RbNaCl::SecretBox.new(plaintext_key)
 
       should_reencrypt = false
@@ -130,7 +179,7 @@ class PorkyLib::Symmetric
       [message, should_reencrypt, encryption_statistics]
     end
 
-    benchmark_block(track_statistics, encryption_statistics, :clear_key) do
+    benchmark_block(encryption_statistics, :clear_key) do
       # Securely delete the plaintext value from memory
       plaintext_key.replace(secure_delete_plaintext_key(plaintext_key.bytesize))
     end
@@ -144,17 +193,13 @@ class PorkyLib::Symmetric
 
   private
 
-  def benchmark_block(benchmark, statistics, stat_label)
-    if benchmark
-      results = nil
+  def benchmark_block(statistics, stat_label)
+    results = nil
 
-      measurement = Benchmark.measure { results = yield }
+    measurement = Benchmark.measure { results = yield }
 
-      statistics[stat_label] = measurement
+    statistics[stat_label] = measurement
 
-      results
-    else
-      yield
-    end
+    results
   end
 end

--- a/spec/porky_lib/symmetric_spec.rb
+++ b/spec/porky_lib/symmetric_spec.rb
@@ -51,6 +51,110 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
     [ciphertext, nonce]
   end
 
+  shared_examples_for 'Encrypt and decrypt tests' do
+    it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      expect(key).not_to be nil
+      expect(data).not_to be nil
+      expect(nonce).not_to be nil
+    end
+
+    it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce with existing data encryption key' do
+      _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, ciphertext_key, default_encryption_context)
+      expect(key).to eq(ciphertext_key)
+      expect(data).not_to be nil
+      expect(nonce).not_to be nil
+    end
+
+    it 'Encrypt returns non-null values with no encryption context for ciphertext key, ciphertext data, and nonce' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id)
+      expect(key).not_to be nil
+      expect(data).not_to be nil
+      expect(nonce).not_to be nil
+    end
+
+    it 'Encrypt with bad CMK key ID raises NotFoundException' do
+      expect do
+        symmetric.send(encrypt_function, plaintext_data, bad_key_id, nil, default_encryption_context)
+      end.to raise_error(Aws::KMS::Errors::NotFoundException)
+    end
+
+    it 'Decrypt returns an expected value' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      result, should_reencrypt = symmetric.send(decrypt_function, key, data, nonce, default_encryption_context)
+      expect(result).to eq(plaintext_data)
+      expect(should_reencrypt).to be_falsey
+    end
+
+    it 'Decrypt with no encryption context returns an expected value' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id)
+      result, should_reencrypt = symmetric.send(decrypt_function, key, data, nonce, nil)
+      expect(result).to eq(plaintext_data)
+      expect(should_reencrypt).to be_falsey
+    end
+
+    it 'Decrypt with bad nonce raises CryptoError' do
+      key, data, = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      expect do
+        symmetric.send(decrypt_function, key, data, SecureRandom.hex(12), default_encryption_context)
+      end.to raise_error(RbNaCl::CryptoError)
+    end
+
+    it 'Decrypt with bad encryption context raises InvalidCiphertextException' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      expect do
+        symmetric.send(decrypt_function, key, data, nonce, bad_encryption_context)
+      end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
+    end
+
+    it 'Decrypt with bad ciphertext data raises CryptoError' do
+      key, _, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      expect do
+        symmetric.send(decrypt_function, key, SecureRandom.base64(data_encryption_key_length), nonce, default_encryption_context)
+      end.to raise_error(RbNaCl::CryptoError)
+    end
+
+    it 'Decrypt with slightly modified data raises CryptoError' do
+      key, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      data_bytes = data.unpack('c*')
+      data_bytes[0] = data_bytes[0] + 1
+      data = data_bytes.pack('c*')
+      expect do
+        symmetric.send(decrypt_function, key, data, nonce, default_encryption_context)
+      end.to raise_error(RbNaCl::CryptoError)
+    end
+
+    it 'Decrypt with bad ciphertext key raises InvalidCiphertextException' do
+      _, data, nonce = symmetric.send(encrypt_function, plaintext_data, default_key_id, nil, default_encryption_context)
+      expect do
+        symmetric.send(decrypt_function, SecureRandom.base64(data_encryption_key_length), data, nonce, default_encryption_context)
+      end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
+    end
+
+    it 'If data was encrypted incorrectly, decrypt and mark as should re-encrypt' do
+      ciphertext, nonce = encrypt_with_bad_key
+      message, should_reencrypt = symmetric.send(decrypt_function, [nil, nil, SecureRandom.random_bytes(data_encryption_key_length)].to_msgpack.reverse,
+                                                 ciphertext, nonce, nil)
+      expect(message).to eq(plaintext_data)
+      expect(should_reencrypt).to be_truthy
+    end
+  end
+
+  describe 'for base encrypt and decrypt' do
+    include_examples 'Encrypt and decrypt tests' do
+      let(:encrypt_function) { :encrypt }
+      let(:decrypt_function) { :decrypt }
+    end
+  end
+
+  describe 'for benchmarked encrypt and decrypt' do
+    include_examples 'Encrypt and decrypt tests' do
+      let(:encrypt_function) { :encrypt_with_benchmark }
+      let(:decrypt_function) { :decrypt_with_benchmark }
+    end
+  end
+
   it 'Generate data encryption key returns non-null values for plaintext_key and ciphertext_key' do
     plaintext_key, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
     expect(plaintext_key).not_to be nil
@@ -61,93 +165,6 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
     expect do
       symmetric.generate_data_encryption_key(bad_key_id, default_encryption_context)
     end.to raise_error(Aws::KMS::Errors::NotFoundException)
-  end
-
-  it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    expect(key).not_to be nil
-    expect(data).not_to be nil
-    expect(nonce).not_to be nil
-  end
-
-  it 'Encrypt returns non-null values for ciphertext key, ciphertext data, and nonce with existing data encryption key' do
-    _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, ciphertext_key, default_encryption_context)
-    expect(key).to eq(ciphertext_key)
-    expect(data).not_to be nil
-    expect(nonce).not_to be nil
-  end
-
-  it 'Encrypt returns non-null values with no encryption context for ciphertext key, ciphertext data, and nonce' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id)
-    expect(key).not_to be nil
-    expect(data).not_to be nil
-    expect(nonce).not_to be nil
-  end
-
-  it 'Encrypt with bad CMK key ID raises NotFoundException' do
-    expect do
-      symmetric.encrypt(plaintext_data, bad_key_id, nil, default_encryption_context)
-    end.to raise_error(Aws::KMS::Errors::NotFoundException)
-  end
-
-  it 'Decrypt returns an expected value' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    result, should_reencrypt = symmetric.decrypt(key, data, nonce, default_encryption_context)
-    expect(result).to eq(plaintext_data)
-    expect(should_reencrypt).to be_falsey
-  end
-
-  it 'Decrypt with no encryption context returns an expected value' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id)
-    result, should_reencrypt = symmetric.decrypt(key, data, nonce, nil)
-    expect(result).to eq(plaintext_data)
-    expect(should_reencrypt).to be_falsey
-  end
-
-  it 'Decrypt with bad nonce raises CryptoError' do
-    key, data, = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    expect do
-      symmetric.decrypt(key, data, SecureRandom.hex(12), default_encryption_context)
-    end.to raise_error(RbNaCl::CryptoError)
-  end
-
-  it 'Decrypt with bad encryption context raises InvalidCiphertextException' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    expect do
-      symmetric.decrypt(key, data, nonce, bad_encryption_context)
-    end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
-  end
-
-  it 'Decrypt with bad ciphertext data raises CryptoError' do
-    key, _, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    expect do
-      symmetric.decrypt(key, SecureRandom.base64(data_encryption_key_length), nonce, default_encryption_context)
-    end.to raise_error(RbNaCl::CryptoError)
-  end
-
-  it 'Decrypt with slightly modified data raises CryptoError' do
-    key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    data_bytes = data.unpack('c*')
-    data_bytes[0] = data_bytes[0] + 1
-    data = data_bytes.pack('c*')
-    expect do
-      symmetric.decrypt(key, data, nonce, default_encryption_context)
-    end.to raise_error(RbNaCl::CryptoError)
-  end
-
-  it 'Decrypt with bad ciphertext key raises InvalidCiphertextException' do
-    _, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-    expect do
-      symmetric.decrypt(SecureRandom.base64(data_encryption_key_length), data, nonce, default_encryption_context)
-    end.to raise_error(Aws::KMS::Errors::InvalidCiphertextException)
-  end
-
-  it 'If data was encrypted incorrectly, decrypt and mark as should re-encrypt' do
-    ciphertext, nonce = encrypt_with_bad_key
-    message, should_reencrypt = symmetric.decrypt([nil, nil, SecureRandom.random_bytes(data_encryption_key_length)].to_msgpack.reverse, ciphertext, nonce, nil)
-    expect(message).to eq(plaintext_data)
-    expect(should_reencrypt).to be_truthy
   end
 
   it 'Create key returns non-null value for key ID' do
@@ -207,126 +224,54 @@ RSpec.describe PorkyLib::Symmetric, type: :request do
   end
 
   # rubocop:disable RSpec/MultipleExpectations
-  describe 'with track_statistics set to true' do
-    describe 'for #encrypt' do
-      it 'returns encryption statistics' do
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id, nil, nil, true)
-        expect(key).not_to be_nil
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).not_to be_nil
+  describe 'for #encrypt_with_benchmark' do
+    it 'returns encryption statistics' do
+      key, data, nonce, stats = symmetric.encrypt_with_benchmark(plaintext_data, default_key_id, nil, nil)
+      expect(key).not_to be_nil
+      expect(data).not_to be_nil
+      expect(nonce).not_to be_nil
+      expect(stats).not_to be_nil
 
-        expect(stats).to have_key(:generate_key)
-        expect(stats).not_to have_key(:decrypt_key)
-        expect(stats).to have_key(:encrypt)
-        expect(stats).to have_key(:clear_key)
-      end
-
-      it 'returns encryption statistics (passed in dek)' do
-        _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id, ciphertext_key, default_encryption_context, true)
-        expect(key).to eq(ciphertext_key)
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).not_to be_nil
-
-        expect(stats).not_to have_key(:generate_key)
-        expect(stats).to have_key(:decrypt_key)
-        expect(stats).to have_key(:encrypt)
-        expect(stats).to have_key(:clear_key)
-      end
+      expect(stats).to have_key(:generate_key)
+      expect(stats).not_to have_key(:decrypt_key)
+      expect(stats).to have_key(:encrypt)
+      expect(stats).to have_key(:clear_key)
     end
 
-    describe 'for #decrypt' do
-      it 'returns encryption statistics when track_statistics is set' do
-        key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        result, should_reencrypt, stats = symmetric.decrypt(key, data, nonce, default_encryption_context, true)
-        expect(result).to eq(plaintext_data)
-        expect(should_reencrypt).to be_falsey
-        expect(stats).not_to be_nil
+    it 'returns encryption statistics (passed in dek)' do
+      _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
+      key, data, nonce, stats = symmetric.encrypt_with_benchmark(plaintext_data, default_key_id, ciphertext_key, default_encryption_context)
+      expect(key).to eq(ciphertext_key)
+      expect(data).not_to be_nil
+      expect(nonce).not_to be_nil
+      expect(stats).not_to be_nil
 
-        expect(stats).to have_key(:decrypt_key)
-        expect(stats).to have_key(:decrypt)
-        expect(stats).to have_key(:clear_key)
-      end
+      expect(stats).not_to have_key(:generate_key)
+      expect(stats).to have_key(:decrypt_key)
+      expect(stats).to have_key(:encrypt)
+      expect(stats).to have_key(:clear_key)
+    end
+  end
 
-      it 'raises exception on decrypt failure when track_statistics is set' do
-        key, data, = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        expect do
-          symmetric.decrypt(key, data, SecureRandom.hex(12), default_encryption_context, true)
-        end.to raise_error(RbNaCl::CryptoError)
-      end
+  describe 'for #decrypt_with_benchmark' do
+    it 'returns encryption statistics when track_statistics is set' do
+      key, data, nonce = symmetric.encrypt_with_benchmark(plaintext_data, default_key_id, nil, default_encryption_context)
+      result, should_reencrypt, stats = symmetric.decrypt_with_benchmark(key, data, nonce, default_encryption_context)
+      expect(result).to eq(plaintext_data)
+      expect(should_reencrypt).to be_falsey
+      expect(stats).not_to be_nil
+
+      expect(stats).to have_key(:decrypt_key)
+      expect(stats).to have_key(:decrypt)
+      expect(stats).to have_key(:clear_key)
+    end
+
+    it 'raises exception on decrypt_with_benchmark failure when track_statistics is set' do
+      key, data, = symmetric.encrypt_with_benchmark(plaintext_data, default_key_id, nil, default_encryption_context)
+      expect do
+        symmetric.decrypt_with_benchmark(key, data, SecureRandom.hex(12), default_encryption_context)
+      end.to raise_error(RbNaCl::CryptoError)
     end
   end
   # rubocop:enable RSpec/MultipleExpectations
-
-  describe 'with track_statistics set to falsey' do
-    describe 'for #encrypt' do
-      it 'returns nil encryption statistics when track_statistics is not set' do
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id)
-        expect(key).not_to be_nil
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).to be_empty
-      end
-
-      it 'returns nil encryption statistics when track statistics is not set (passed in dek)' do
-        _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id, ciphertext_key, default_encryption_context)
-        expect(key).to eq(ciphertext_key)
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).to be_empty
-      end
-
-      it 'returns nil encryption statistics when track_statistics is set to false' do
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id, nil, nil, false)
-        expect(key).not_to be_nil
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).to be_empty
-      end
-
-      it 'returns nil encryption statistics when track statistics is set to false (passed in dek)' do
-        _, ciphertext_key = symmetric.generate_data_encryption_key(default_key_id, default_encryption_context)
-        key, data, nonce, stats = symmetric.encrypt(plaintext_data, default_key_id, ciphertext_key, default_encryption_context, false)
-        expect(key).to eq(ciphertext_key)
-        expect(data).not_to be_nil
-        expect(nonce).not_to be_nil
-        expect(stats).to be_empty
-      end
-    end
-
-    describe 'for #decrypt' do
-      it 'returns nil encryption statistics when track_statistics is not set' do
-        key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        result, should_reencrypt, stats = symmetric.decrypt(key, data, nonce, default_encryption_context)
-        expect(result).to eq(plaintext_data)
-        expect(should_reencrypt).to be_falsey
-        expect(stats).to be_empty
-      end
-
-      it 'raises an exception on decryption error when track_statistics is not set' do
-        key, data, = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        expect do
-          symmetric.decrypt(key, data, SecureRandom.hex(12), default_encryption_context)
-        end.to raise_error(RbNaCl::CryptoError)
-      end
-
-      it 'returns nil encryption statistics when track_statistics is set to false' do
-        key, data, nonce = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        result, should_reencrypt, stats = symmetric.decrypt(key, data, nonce, default_encryption_context, false)
-        expect(result).to eq(plaintext_data)
-        expect(should_reencrypt).to be_falsey
-        expect(stats).to be_empty
-      end
-
-      it 'raises an exception on decryption error when track_statistics is set to false' do
-        key, data, = symmetric.encrypt(plaintext_data, default_key_id, nil, default_encryption_context)
-        expect do
-          symmetric.decrypt(key, data, SecureRandom.hex(12), default_encryption_context, false)
-        end.to raise_error(RbNaCl::CryptoError)
-      end
-    end
-  end
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Progress on https://github.com/Zetatango/zetatango/issues/5322

*Why?*

We want to instrument the encryption and decryption processes to:

1. Monitor their performance over time
1. Determine which parts of the process are the bottlenecks
1. Measure the performance increase from changes

*How?*

1. Optionally wrap specific parts of the processes in Benchmark calls (when enabled)
1. Return the timing results to the caller

*Risks*

Any time the encryption or decryption processes are changed there is significant risk to the platform.

*Requested Reviewers*

@dragoszt, @gregfletch and @bvrooman please review
