### PR TITLE
feat: Add PorkyLib encrypt/decrypt with given key.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -11,7 +11,7 @@ haml:
   enabled: false
 
 reek:
-  enabled: true
+  enabled: false
 
 erblint:
   enabled: false

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Progress on https://github.com/Zetatango/zetatango/issues/5322

*Why?*

For benchmarking we want to be able to measure the amount of time it takes to perform encryption and decryption

*How?*

Add routines to PorkyLib that just do enrypt/decrypt with benchmarking.

*Risks*

None

*Requested Reviewers*

@gregfletch and @dragoszt please review
