### PR TITLE
feat: Add encrypt/decrypt with specific key.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.6.2)
+    porky_lib (0.7.0)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ To encrypt data:
 [ciphertext_dek, ciphertext, nonce] = PorkyLib::Symmetric.instance.encrypt(data, cmk_key_id, ciphertext_dek, encryption_context)
 ```
 
+To encrypt data with a known plaintext key:
+```ruby
+# Where plaintext is the data to encrypt
+# plaintext_key is the encryption key to use
+# encryption_info is the structure returned that contains:
+#   ciphertext: plaintext encrypted under plaintext_key
+#   nonce: The generated nonce 
+encryption_info = PorkyLib::Symmetric.instance.encrypt_with_key(plaintext, plaintext_key)
+```
+
 ### Decrypting Data
 To decrypt data:
 ```ruby
@@ -84,6 +94,16 @@ To decrypt data:
 # nonce is the nonce value associated with ciphertext
 # encryption_context is an optional parameter to provide additional authentication data for decrypting the DEK. Default is nil. Note, this must match the value that was used to encrypt.
 plaintext_data = PorkyLib::Symmetric.instance.decrypt(ciphertext_dek, ciphertext, nonce, encryption_context)
+```
+
+To decrypt data with a known plaintext key:
+```ruby
+# Where ciphertext is the encrypted data to be decrypted
+# plaintext_key is the decryption key to use
+# nonce is the nonce to use 
+# decryption_info is the structured returned that contains:
+#   plaintext: ciphertext decrypted under plaintext_key
+decryption_info = PorkyLib::Symmetric.instance.decrypt_with_key(ciphertext, plaintext_key, nonce)
 ```
 
 ### Generating Data Encryption Keys

--- a/lib/porky_lib/symmetric.rb
+++ b/lib/porky_lib/symmetric.rb
@@ -191,6 +191,40 @@ class PorkyLib::Symmetric
     "\0" * length
   end
 
+  def encrypt_with_key(plaintext, plaintext_key)
+    # Initialize the box
+    secret_box = RbNaCl::SecretBox.new(plaintext_key)
+
+    # First, make a nonce: A single-use value never repeated under the same key
+    # The nonce isn't secret, and can be sent with the ciphertext.
+    # The cipher instance has a nonce_bytes method for determining how many bytes should be in a nonce
+    nonce = RbNaCl::Random.random_bytes(secret_box.nonce_bytes)
+
+    # Encrypt a message with SecretBox
+    ciphertext = secret_box.encrypt(nonce, plaintext)
+
+    result = OpenStruct.new
+
+    result.ciphertext = ciphertext
+    result.nonce = nonce
+
+    result
+  end
+
+  def decrypt_with_key(ciphertext, plaintext_key, nonce)
+    # Initialize the box
+    secret_box = RbNaCl::SecretBox.new(plaintext_key)
+
+    # Decrypt the message
+    plaintext = secret_box.decrypt(nonce, ciphertext)
+
+    result = OpenStruct.new
+
+    result.plaintext = plaintext
+
+    result
+  end
+
   def encrypt_with_key_with_benchmark(plaintext, plaintext_key)
     encryption_statistics = {}
 

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Progress on https://github.com/Zetatango/zetatango/issues/5322

*Why?*

Benchmarking showed that we can significantly improve performance of db encryption/decryption by partitioning data and caching encryption keys. To enable this performance improvement we need to add two new functions to PorkyLib encrypt/decrypt that take in a key to use for the operations.

*How?*

Add `encrypt_with_key` and `decrypt_with_key` functions.

*Risks*

This follows the same algorithm that was being used before, it just doesn't register a new key when performing encryption now.

*Requested Reviewers*

@dragoszt, @nachozt and @gregfletch please review
