### PR TITLE
add presigned_post_url and presigned_get_url

### DIFF
--- a/lib/porky_lib/config.rb
+++ b/lib/porky_lib/config.rb
@@ -6,13 +6,15 @@ class PorkyLib::Config
   @aws_key_secret = ''
   @aws_client_mock = false
   @max_file_size = 0
+  @presign_url_expires_in = 300 # 5 minutes
 
   @config = {
     aws_region: @aws_region,
     aws_key_id: @aws_key_id,
     aws_key_secret: @aws_key_secret,
     aws_client_mock: @aws_client_mock,
-    max_file_size: @max_file_size
+    max_file_size: @max_file_size,
+    presign_url_expires_in: @presign_url_expires_in
   }
 
   @allowed_config_keys = @config.keys

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -91,6 +91,28 @@ class PorkyLib::FileService
     tempfile.unlink
   end
 
+  def presigned_post_url(bucket_name, options = {})
+    file_name = options[:file_name] || SecureRandom.uuid
+    obj = s3.bucket(bucket_name).object(file_name)
+
+    presigned_url = obj.presigned_url(:put,
+                                      server_side_encryption: 'aws:kms',
+                                      expires_in: presign_url_expires_in,
+                                      metadata: options[:metadata])
+    [presigned_url, file_name]
+  rescue Aws::Errors::ServiceError => e
+    raise FileServiceError, "PresignedPostUrl for #{file_name} from S3 bucket #{bucket_name} failed: #{e.message}"
+  end
+
+  def presigned_get_url(bucket_name, file_key)
+    obj = s3.bucket(bucket_name).object(file_key)
+
+    obj.presigned_url(:get,
+                      expires_in: presign_url_expires_in)
+  rescue Aws::Errors::ServiceError => e
+    raise FileServiceError, "PresignedGetUrl for #{file_key} from S3 bucket #{bucket_name} failed: #{e.message}"
+  end
+
   private
 
   def input_invalid?(file, bucket_name, key_id)
@@ -169,6 +191,10 @@ class PorkyLib::FileService
     tempfile.close
 
     tempfile
+  end
+
+  def presign_url_expires_in
+    PorkyLib::Config.config[:presign_url_expires_in]
   end
 
   def s3_client

--- a/spec/porky_lib/config_spec.rb
+++ b/spec/porky_lib/config_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe PorkyLib::Config, type: :request do
       aws_key_id: '',
       aws_key_secret: '',
       aws_client_mock: true,
-      max_file_size: 0 }
+      max_file_size: 0,
+      presign_url_expires_in: 300 }
   end
 
   before do


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/5523

*Why?*

Preparation for encryption performance issue proposal described in the issue ^

*How?*

Added capabilities to:
- generate presigned_post_url => this will be used to upload documents directly from the frontend client to s3.
- generate presigned_get_url => this will be used to get a url to download an object

Summary:
- `presign_url_expires_in` added to be configurable. Default to 5 minutes.
- `presigned_post_url` only receives bucket_name. If file_key is not provided, it generates a random one. Accepts metadata, and sets server side encryption with kms.
- `presigned_get_url` receives bucket name and object key. 

*Risks*

Explain the risks that are involved with making this change, if any.
