### PR TITLE
Fixed null byte error in pathname

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.9.1)
+    porky_lib (0.9.2)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ file_data = PorkyLib::Unencrypted::FileService.read(bucket_name, file_key)
 
 ### To Write To AWS S3
 ```ruby
-# Where file is the data to encrypt and upload to S3 (can be raw data or path to a file on disk)
+# Where file is the data to encrypt and upload to S3 (can be raw data or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
 # key_id is the ID of the CMK to use to generate a data encryption key to encrypt the file data
 # options is an optional parameter for specifying optional metadata about the file
@@ -165,7 +165,7 @@ file_key = PorkyLib::FileService.write(file, bucket_name, key_id, options)
 
 ### To Write Unencrypted Files To AWS S3
 ```ruby
-# Where file is the data to upload to S3 (can be raw data or path to a file on disk)
+# Where file is the data to upload to S3 (can be raw data or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
 # options is an optional parameter for specifying optional metadata about the file
 file_key = PorkyLib::Unencrypted::FileService.write(file, bucket_name, options)

--- a/lib/porky_lib/file_service_helper.rb
+++ b/lib/porky_lib/file_service_helper.rb
@@ -4,11 +4,11 @@ require 'aws-sdk-s3'
 
 module PorkyLib::FileServiceHelper
   def file_size_invalid?(file)
-    file.bytesize > max_size || (File.file?(file) && File.size(file) > max_size)
+    (file.is_a?(String) && file.bytesize > max_size) || (!file.is_a?(String) && File.size(file) > max_size)
   end
 
   def file_data(file)
-    File.file?(file) ? File.read(file) : file
+    file.is_a?(String) ? file : File.read(file)
   end
 
   def write_tempfile(file_contents, file_key)

--- a/lib/porky_lib/file_service_helper.rb
+++ b/lib/porky_lib/file_service_helper.rb
@@ -3,12 +3,16 @@
 require 'aws-sdk-s3'
 
 module PorkyLib::FileServiceHelper
-  def file_size_invalid?(file)
-    (file.is_a?(String) && file.bytesize > max_size) || (!file.is_a?(String) && File.size(file) > max_size)
+  def file_size_invalid?(file_or_content)
+    if a_file?(file_or_content)
+      File.size(file_or_content) > max_size
+    else
+      file_or_content.bytesize > max_size
+    end
   end
 
-  def file_data(file)
-    file.is_a?(String) ? file : File.read(file)
+  def file_data(file_or_content)
+    a_file?(file_or_content) ? File.read(file_or_content) : file_or_content
   end
 
   def write_tempfile(file_contents, file_key)
@@ -47,5 +51,11 @@ module PorkyLib::FileServiceHelper
 
   def generate_file_key(options)
     options.key?(:directory) ? "#{options[:directory]}/#{SecureRandom.uuid}" : SecureRandom.uuid
+  end
+
+  private
+
+  def a_file?(file_or_content)
+    !file_or_content.is_a?(String)
   end
 end

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end

--- a/spec/porky_lib/unencrypted/file_service_spec.rb
+++ b/spec/porky_lib/unencrypted/file_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
   def write_test_file(data)
     tempfile = Tempfile.new
     tempfile << data
-    tempfile.close
+    tempfile.flush
     tempfile
   end
 
@@ -83,20 +83,20 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
     end
 
     it 'write file to S3' do
-      file_key = file_service.write(write_test_file(plaintext_data).path, bucket_name)
+      file_key = file_service.write(write_test_file(plaintext_data), bucket_name)
       expect(file_key).not_to be_nil
     end
 
     it 'write large file to S3' do
       PorkyLib::Config.configure(max_file_size: 10 * 1024)
       expect do
-        file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).path,
+        file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")),
                            bucket_name)
       end.to raise_exception(PorkyLib::Unencrypted::FileService::FileSizeTooLargeError)
     end
 
     it 'write file too large to S3' do
-      file_key = file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")).path,
+      file_key = file_service.write(write_test_file(File.read("spec#{File::SEPARATOR}porky_lib#{File::SEPARATOR}data#{File::SEPARATOR}large_plaintext")),
                                     bucket_name)
       expect(file_key).not_to be_nil
     end
@@ -104,7 +104,7 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
     it 'write file to S3 with metadata' do
       tempfile = write_test_file(plaintext_data)
       metadata = { content_type: 'test/data' }
-      file_key = file_service.write(tempfile.path, bucket_name, metadata: metadata)
+      file_key = file_service.write(tempfile, bucket_name, metadata: metadata)
       expect(file_key).not_to be_nil
     end
 
@@ -203,5 +203,18 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
         file_service.read(bucket_name, default_key_id)
       end.to raise_exception(PorkyLib::Unencrypted::FileService::FileServiceError)
     end
+  end
+
+  it 'file_size_invalid? handles contents containing a null byte when reading a file' do
+    null_byte_contents = "\xA0\0"
+    file_key = file_service.write(null_byte_contents, bucket_name)
+    expect(file_key).not_to be_nil
+  end
+
+  it 'file_size_invalid? handles content encoded as ASCII_8BIT (BINARY) when creating the tempfile' do
+    # ASCII_8BIT String with character, \xC3, has undefined conversion from ACSII-8BIT to UTF-8
+    my_file_contents = "\xC3Hello"
+    file_key = file_service.write(my_file_contents, bucket_name)
+    expect(file_key).not_to be_nil
   end
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Part of https://github.com/Zetatango/zetatango/issues/6272

*Why?*

If the user uploads a document containing binary data (like an image), PorkyLib would throw a null byte in path error. The `File.file?(file)` would throw this error and this check has now been replaced with `file.is_a?(String)`, with a slightly different logic.

*How?*

To fix this issue, PorkyLib will not support the use of paths for the `write` methods in FileService for both encrypted an unencrypted, since I removed the option to open a file because it would conflict with the new logic of checking if the file is a String.

*Risks*

May break some code if we are using the `write` method with a path.

*Requested Reviewers*

@nachozt and @dragoszt 
