### PR TITLE
Removed deprecation warning for overwrite_file and deprecated file_data method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.9.3)
+    porky_lib (0.9.4)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -91,11 +91,10 @@ class PorkyLib::FileService
     file_key
   end
 
-  def overwrite_file(file, file_key, bucket_name, key_id, options = {})
-    raise FileServiceError, 'Invalid input. One or more input values is nil' if overwrite_input_invalid?(file, file_key, bucket_name, key_id)
+  def overwrite_file(data, file_key, bucket_name, key_id, options = {})
+    raise FileServiceError, 'Invalid input. One or more input values is nil' if overwrite_input_invalid?(data, file_key, bucket_name, key_id)
     raise FileServiceError, 'Invalid input. file_key cannot be nil if overwriting an existing file' if file_key.nil?
 
-    data = file_data(file)
     raise FileSizeTooLargeError, "File size is larger than maximum allowed size of #{max_file_size}" if data_size_invalid?(data)
 
     tempfile = encrypt_file_contents(data, key_id, file_key, options)
@@ -109,7 +108,6 @@ class PorkyLib::FileService
     # Remove tempfile from disk
     tempfile.unlink
   end
-  deprecate :overwrite_file, :none, 2020, 0o1
 
   def presigned_post_url(bucket_name, options = {})
     file_name = options[:file_name] || SecureRandom.uuid

--- a/lib/porky_lib/file_service_helper.rb
+++ b/lib/porky_lib/file_service_helper.rb
@@ -11,15 +11,6 @@ module PorkyLib::FileServiceHelper
     data.bytesize > max_size
   end
 
-  def file_data(file_or_content)
-    if file?(file_or_content)
-      read_file(file_or_content)
-    else
-      file_or_content
-    end
-  end
-  deprecate :file_data, :none, 2020, 1
-
   def file?(file_or_content)
     a_file?(file_or_content) || a_path?(file_or_content)
   end

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -341,31 +341,6 @@ RSpec.describe PorkyLib::FileService, type: :request do
   end
 
   describe '#overwrite' do
-    it 'overwrites the right content to S3 if file object is used' do
-      file = write_test_file(plaintext_data)
-
-      expect do
-        file_service.overwrite_file(file, default_file_key, bucket_name, default_key_id)
-      end.not_to raise_exception
-    end
-
-    it 'overwrites the right content to S3 if path is used' do
-      path = write_test_file(plaintext_data).path
-
-      expect do
-        file_service.overwrite_file(path, default_file_key, bucket_name, default_key_id)
-      end.not_to raise_exception
-    end
-
-    it 'overwrites FileServiceError when file cannot be read (no permission)' do
-      path = write_test_file(plaintext_data).path
-
-      expect do
-        File.chmod(0o000, path)
-        file_service.overwrite_file(path, default_file_key, bucket_name, default_key_id)
-      end.to raise_exception(PorkyLib::FileServiceHelper::FileServiceError)
-    end
-
     it 'overwrites encrypted data to S3' do
       expect do
         file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, default_key_id)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

Cleaning up porky_lib deprecation warnings.

*Why?*

The `overwrite_file` method is still a useful method, there has been some miscommunication.

*How?*

1. Removed deprecation warning for `overwrite_file` and made it only work for data passed to it.
2. Removed deprecated method `file_data` which was only used by `overwrite_file` to get data from either a file or content. (This method was private previously in `file_service.rb` and is not used anywhere in our code)

*Risks*

Low

*Requested Reviewers*

@dragoszt @gregfletch 
