### PR TITLE
Added write/read S3 rake tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.9.4)
+    porky_lib (0.9.5)
       aws-sdk-kms
       aws-sdk-s3
       msgpack

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ url = PorkyLib::Symmetric.instance.presigned_get_url(bucket_name, file_key)
 ## Rake task
 If you want to write or read an encrypted file from the command line, there is a Rake write and read task.
 
-> Note: the environment variables can be set globally or by prepending the rake task command
+> Note: the environment variables can be set globally or by prepending them to the rake task command
 
 ### Write file
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ file_data = PorkyLib::Unencrypted::FileService.read(bucket_name, file_key)
 # Where file is the data to encrypt and upload to S3 (can be a path or raw data or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
 # key_id is the ID of the CMK to use to generate a data encryption key to encrypt the file data
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::FileService.write(file, bucket_name, key_id, options)
 ```
 
@@ -169,7 +169,7 @@ file_key = PorkyLib::FileService.write(file, bucket_name, key_id, options)
 # Where file is the data to encrypt and upload to S3 (can be a path or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
 # key_id is the ID of the CMK to use to generate a data encryption key to encrypt the file data
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::FileService.write_file(file, bucket_name, key_id, options)
 ```
 
@@ -178,7 +178,7 @@ file_key = PorkyLib::FileService.write_file(file, bucket_name, key_id, options)
 # Where data is the raw data to encrypt and upload to S3
 # bucket_name is the name of the S3 bucket to write to
 # key_id is the ID of the CMK to use to generate a data encryption key to encrypt the file data
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::FileService.write_data(data, bucket_name, key_id, options)
 ```
 
@@ -187,7 +187,7 @@ file_key = PorkyLib::FileService.write_data(data, bucket_name, key_id, options)
 # --- DEPRECATED --- Please use write_data or write_file instead of write
 # Where file is the data to upload to S3 (can be a path or raw data or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::Unencrypted::FileService.write(file, bucket_name, options)
 ```
 
@@ -195,7 +195,7 @@ file_key = PorkyLib::Unencrypted::FileService.write(file, bucket_name, options)
 ```ruby
 # Where file is the data to encrypt and upload to S3 (can be a path or ruby file object)
 # bucket_name is the name of the S3 bucket to write to
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::Unencrypted::FileService.write_file(file, bucket_name, options)
 ```
 
@@ -203,7 +203,7 @@ file_key = PorkyLib::Unencrypted::FileService.write_file(file, bucket_name, opti
 ```ruby
 # Where data is the raw data to encrypt and upload to S3
 # bucket_name is the name of the S3 bucket to write to
-# options is an optional parameter for specifying optional metadata about the file
+# options is an optional parameter for specifying optional metadata about the file and the storage_class of the object
 file_key = PorkyLib::Unencrypted::FileService.write_data(data, bucket_name, options)
 ```
 
@@ -223,6 +223,45 @@ To generate a new presigned GET url (used to download files directly from AWS S3
 # file_key is the file identifier of the file/data that was written to S3.
 url = PorkyLib::Symmetric.instance.presigned_get_url(bucket_name, file_key)
 ```
+
+## Rake task
+If you want to write or read an encrypted file from the command line, there is a Rake write and read task.
+
+> Note: the environment variables can be set globally or by prepending the rake task command
+
+### Write file
+
+Rake task name: `file:write`
+
+Environment variables:
+* Required
+  * `FILE_PATH` - Absolute or relative file path 
+  * `CMK_KEY_ID` - Alias of the CMK key
+  * `AWS_S3_BUCKET` - AWS S3 bucket name
+  * `AWS_REGION` - AWS region name
+  * `AWS_ACCESS_KEY_ID` - AWS access key ID (credentials)
+  * `AWS_ACCESS_KEY` - AWS secret access key (credentials)
+* Optional
+  * `AWS_S3_MOCK_CLIENT` - PorkyLib's AWS KMS mock client (defaults to `true`)
+  * `AWS_S3_MAX_FILE_SIZE` - Max file size (defaults to `1MB`)
+  * `AWS_S3_STORAGE_CLASS` - One of STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE (defaults to `STANDARD`)
+  * `AWS_S3_KEEP_FILE_NAME` - Saves the file in AWS S3 with the original file name (defaults to `true`)
+  
+### Read file
+
+Rake task name: `file:read`
+
+Environment variables:
+* Required
+  * `FILE_KEY` - AWS S3 object file key
+  * `AWS_S3_BUCKET` - AWS S3 bucket name
+  * `AWS_REGION` - AWS region name
+  * `AWS_ACCESS_KEY_ID` - AWS access key ID (credentials)
+  * `AWS_ACCESS_KEY` - AWS secret access key (credentials)
+* Optional
+  * `AWS_S3_MOCK_CLIENT` - PorkyLib's AWS KMS mock client (defaults to `true`)
+  * `AWS_S3_MAX_FILE_SIZE` - Max file size (defaults to `1MB`)
+  * `DESTINATION` - Location to save the file (defaults to `FILE_KEY`)
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,6 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 import 'lib/tasks/file.rake'
 
-# require 'lib/tasks'
-
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+import 'lib/tasks/file.rake'
+
+# require 'lib/tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/lib/porky_lib/file_service.rb
+++ b/lib/porky_lib/file_service.rb
@@ -77,7 +77,11 @@ class PorkyLib::FileService
     raise FileServiceError, 'Invalid input. One or more input values is nil' if input_invalid?(data, bucket_name, key_id)
     raise FileSizeTooLargeError, "Data size is larger than maximum allowed size of #{max_file_size}" if data_size_invalid?(data)
 
-    file_key = generate_file_key(options)
+    file_key = if options.key?(:file_name)
+                 options[:file_name]
+               else
+                 generate_file_key(options)
+               end
     tempfile = encrypt_file_contents(data, key_id, file_key, options)
 
     begin

--- a/lib/porky_lib/file_service_helper.rb
+++ b/lib/porky_lib/file_service_helper.rb
@@ -36,11 +36,13 @@ module PorkyLib::FileServiceHelper
 
   def perform_upload(bucket_name, file_key, tempfile, options)
     obj = s3.bucket(bucket_name).object(file_key)
-    if options.key?(:metadata)
-      obj.upload_file(tempfile.path, metadata: options[:metadata])
-    else
-      obj.upload_file(tempfile.path)
-    end
+
+    upload_options = {
+      metadata: (options[:metadata] if options.key?(:metadata)),
+      storage_class: (options[:storage_class] if options.key?(:storage_class))
+    }.compact
+
+    obj.upload_file(tempfile.path, upload_options)
   end
 
   def s3

--- a/lib/porky_lib/unencrypted/file_service.rb
+++ b/lib/porky_lib/unencrypted/file_service.rb
@@ -47,7 +47,11 @@ class PorkyLib::Unencrypted::FileService
     raise FileServiceError, 'Invalid input. One or more input values is nil' if input_invalid?(data, bucket_name)
     raise FileSizeTooLargeError, "Data size is larger than maximum allowed size of #{max_file_size}" if data_size_invalid?(data)
 
-    file_key = generate_file_key(options)
+    file_key = if options.key?(:file_name)
+                 options[:file_name]
+               else
+                 generate_file_key(options)
+               end
     tempfile = write_tempfile(data, file_key)
 
     begin

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end

--- a/lib/tasks/file.rake
+++ b/lib/tasks/file.rake
@@ -3,7 +3,7 @@
 require 'porky_lib'
 
 namespace :file do
-  desc "Read a file to AWS S3"
+  desc "Read a file from AWS S3"
   task :read do
     # Optional arguments
     use_mock_client = ENV.fetch('AWS_S3_MOCK_CLIENT', 'true') == 'true'

--- a/lib/tasks/file.rake
+++ b/lib/tasks/file.rake
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'porky_lib'
+
+namespace :file do
+  desc "Read a file to AWS S3"
+  task :read do
+    # Optional arguments
+    use_mock_client = ENV.fetch('AWS_S3_MOCK_CLIENT', 'true') == 'true'
+    max_file_size = ENV.fetch('AWS_S3_MAX_FILE_SIZE', 1_048_576).to_i
+    destination = ENV.fetch('DESTINATION', ENV['FILE_KEY'])
+
+    # Required arguments
+    arguments = {
+      file_key: ENV['FILE_KEY'],
+      aws_s3_bucket: ENV['AWS_S3_BUCKET'],
+      aws_region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_access_key: ENV['AWS_ACCESS_KEY']
+    }
+
+    # Checks presence of required arguments and configures porky_lib
+    check_arguments(arguments)
+    setup_porky_lib(arguments, use_mock_client, max_file_size)
+
+    # Reads and writes the file
+    message, = PorkyLib::FileService.instance.read(arguments[:aws_s3_bucket], arguments[:file_key])
+    file = File.open(destination, 'w')
+    file.puts(message)
+    file.close
+
+    puts "SUCCESS - Saved file: '#{destination}' with content of the bucket: '#{arguments[:aws_s3_bucket]}' with file_key: '#{arguments[:file_key]}'"
+  end
+
+  desc "Write a file to AWS S3"
+  task :file do
+    # Optional arguments
+    use_mock_client = ENV.fetch('AWS_S3_MOCK_CLIENT', 'true') == 'true'
+    max_file_size = ENV.fetch('AWS_S3_MAX_FILE_SIZE', 1_048_576).to_i
+    storage_class = ENV.fetch('AWS_S3_STORAGE_CLASS', 'STANDARD')
+    keep_file_name = ENV.fetch('AWS_S3_KEEP_FILE_NAME', 'true') == 'true'
+
+    # Required arguments
+    arguments = {
+      file_path: ENV['FILE_PATH'],
+      cmk_key_id: ENV['CMK_KEY_ID'],
+      aws_s3_bucket: ENV['AWS_S3_BUCKET'],
+      aws_region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_access_key: ENV['AWS_ACCESS_KEY']
+    }
+
+    # Checks presence of required arguments and configures porky_lib
+    check_arguments(arguments)
+    setup_porky_lib(arguments, use_mock_client, max_file_size)
+
+    write_options = {
+      storage_class: storage_class,
+      file_name: (File.basename(arguments[:file_path]) if keep_file_name)
+    }.compact
+
+    # Creates CMK key with empty tags and stores file
+    PorkyLib::Symmetric.instance.create_key([{}], arguments[:cmk_key_id]) unless PorkyLib::Symmetric.instance.cmk_alias_exists?(arguments[:cmk_key_id])
+    file_key = PorkyLib::FileService.instance.write_file(arguments[:file_path], arguments[:aws_s3_bucket], arguments[:cmk_key_id], write_options)
+
+    puts "SUCCESS - Created file: '#{arguments[:file_path]}' bucket: '#{arguments[:aws_s3_bucket]}' file_key: '#{file_key}'"
+  end
+end
+
+private
+
+def check_arguments(arguments)
+  nil_arguments = []
+  arguments.map { |key, value| nil_arguments.push(key.to_s.upcase) if value.nil? && !key.nil? }
+  abort "ERROR - Need to provide as environment variables: #{nil_arguments.join(', ')}" unless nil_arguments.empty?
+end
+
+def setup_porky_lib(arguments, use_mock_client, max_file_size)
+  PorkyLib::Config.configure(aws_region: arguments[:aws_region],
+                             aws_key_id: arguments[:aws_access_key_id],
+                             aws_key_secret: arguments[:aws_access_key],
+                             aws_client_mock: use_mock_client,
+                             max_file_size: max_file_size)
+  PorkyLib::Config.initialize_aws
+end

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -258,6 +258,18 @@ RSpec.describe PorkyLib::FileService, type: :request do
       expect(file_key).not_to be_nil
     end
 
+    it 'writes plaintext data to S3 with a different storage_class' do
+      storage_class = 'REDUCED_REDUNDANCY'
+      file_key = file_service.write_data(plaintext_data, bucket_name, storage_class: storage_class)
+      expect(file_key).not_to be_nil
+    end
+
+    it 'writes encrypted data to S3 with a custom file name' do
+      custom_file_name = 'custom_file_name'
+      file_key = file_service.write_data(plaintext_data, bucket_name, default_key_id, file_name: custom_file_name)
+      expect(file_key).to eq(custom_file_name)
+    end
+
     it 'writes encrypted data to S3 with directory' do
       file_key = file_service.write_data(plaintext_data, bucket_name, default_key_id, directory: '/directory1/dirA')
       expect(file_key).not_to be_nil

--- a/spec/porky_lib/unencrypted/file_service_spec.rb
+++ b/spec/porky_lib/unencrypted/file_service_spec.rb
@@ -203,6 +203,18 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
       expect(file_key).not_to be_nil
     end
 
+    it 'writes plaintext data to S3 with a different storage_class' do
+      storage_class = 'REDUCED_REDUNDANCY'
+      file_key = file_service.write_data(plaintext_data, bucket_name, storage_class: storage_class)
+      expect(file_key).not_to be_nil
+    end
+
+    it 'writes encrypted data to S3 with a custom file name' do
+      custom_file_name = 'custom_file_name'
+      file_key = file_service.write_data(plaintext_data, bucket_name, file_name: custom_file_name)
+      expect(file_key).to eq(custom_file_name)
+    end
+
     it 'writes plaintext data to S3 with directory' do
       file_key = file_service.write_data(plaintext_data, bucket_name, directory: '/directory1/dirA')
       expect(file_key).not_to be_nil


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/devops/issues/106

*Why?*

To be able to upload/download file from AWS S3 from the command line, to be used to perform backups.

*How?*

* Created two rake tasks, one to read a file object from AWS S3 and another to write a file to AWS S3.
* Added option to keep the original file name in S3 and specify the `storage_class` of the S3 object

__Rake task name: `file:write`__

Environment variables:
* Required
  * `FILE_PATH` - Absolute or relative file path 
  * `CMK_KEY_ID` - Alias of the CMK key
  * `AWS_S3_BUCKET` - AWS S3 bucket name
  * `AWS_REGION` - AWS region name
  * `AWS_ACCESS_KEY_ID` - AWS access key ID (credentials)
  * `AWS_ACCESS_KEY` - AWS secret access key (credentials)
* Optional
  * `AWS_S3_MOCK_CLIENT` - PorkyLib's AWS KMS mock client (defaults to `true`)
  * `AWS_S3_MAX_FILE_SIZE` - Max file size (defaults to `1MB`)
  * `AWS_S3_STORAGE_CLASS` - One of STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE (defaults to `STANDARD`)
  * `AWS_S3_KEEP_FILE_NAME` - Saves the file in AWS S3 with the original file name (defaults to `true`)

__Rake task name: `file:read`__

Environment variables:
* Required
  * `FILE_KEY` - AWS S3 object file key
  * `AWS_S3_BUCKET` - AWS S3 bucket name
  * `AWS_REGION` - AWS region name
  * `AWS_ACCESS_KEY_ID` - AWS access key ID (credentials)
  * `AWS_ACCESS_KEY` - AWS secret access key (credentials)
* Optional
  * `AWS_S3_MOCK_CLIENT` - PorkyLib's AWS KMS mock client (defaults to `true`)
  * `AWS_S3_MAX_FILE_SIZE` - Max file size (defaults to `1MB`)
  * `DESTINATION` - Location to save the file (defaults to `FILE_KEY`)

*Risks*

Low

*Requested Reviewers*

@zs787 @dragoszt 