### PR TITLE
Fix rubocop config warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Security/YAMLLoad:
 Security/JSONLoad:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 160
 
 Metrics/ClassLength:
@@ -59,3 +59,12 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 10
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/lib/porky_lib/aws/kms/client.rb
+++ b/lib/porky_lib/aws/kms/client.rb
@@ -72,7 +72,7 @@ class Aws::KMS::Client
 
   def decrypt(ciphertext_blob:, encryption_context: nil)
     key_id, decoded_context, plaintext = MessagePack.unpack(ciphertext_blob.reverse)
-    decoded_context = Hash[decoded_context.map { |k, v| [k.to_sym, v] }] if decoded_context
+    decoded_context = decoded_context.transform_keys(&:to_sym) if decoded_context
     raise Aws::KMS::Errors::InvalidCiphertextException.new(nil, nil) unless decoded_context == encryption_context
 
     Aws::KMS::Types::DecryptResponse.new(


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8729

*Why?*

We were getting annoying warnings about cops not being enabled.

*How?*

Update the rubocop config to enable the new cops.

*How did this defect occur?*

Rubocop was updated by dependabot and this was not noticed at first

*Risks*

Low

*Requested Reviewers*

@DominicRoyStang @dragoszt 
