### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/porky_lib
     docker:
-      - image: circleci/ruby:2.7.0
+      - image: circleci/ruby:2.7.1
 
     steps:
       - checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - output/**/*
     - vendor/**/*
     - spec/porky_lib/data/*
-  TargetRubyVersion: 2.7.0
+  TargetRubyVersion: 2.7.1
   RSpec:
     Patterns:
       - _spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.7.0'
+ruby '2.7.1'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    porky_lib (0.10.0)
+    porky_lib (0.10.1)
       aws-sdk-kms
       aws-sdk-s3
       msgpack
@@ -123,7 +123,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -273,13 +273,19 @@ the likelihood of the pull request being accepted.
 
 This application requires:
 
-*   Ruby version: 2.7.0
+*   Ruby version: 2.7.1
+
+Ruby 2.7.1 and greater requires OpenSSL 1.1+. To link to Homebrew's upgraded version of OpenSSL, add the following to your bash profile
+
+```shell script
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
+```
 
 If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
 
 ```bash
 brew install ruby-install chruby
-ruby-install ruby 2.7.0
+ruby-install ruby 2.7.1
 ```
 
 Add the following lines to ~/.bash_profile:
@@ -289,11 +295,11 @@ source /usr/local/opt/chruby/share/chruby/chruby.sh
 source /usr/local/opt/chruby/share/chruby/auto.sh
 ```
 
-Set Ruby version to 2.7.0:
+Set Ruby version to 2.7.1:
 
 ```bash
 source ~/.bash_profile
-chruby 2.7.0
+chruby 2.7.1
 ```
 
 ### Running Tests

--- a/lib/porky_lib/version.rb
+++ b/lib/porky_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PorkyLib
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

Closes https://github.com/Zetatango/zetatango/issues/9162

*Why?*

There was a CVE (https://www.ruby-lang.org/en/news/2020/03/31/heap-exposure-in-socket-cve-2020-10933/) associated with ruby 2.7.0 and version 2.7.1 was published with a fix to the CVE.

*How?*

Upgrade ruby version by running `ruby-install ruby 2.7.1`.

*How did this defect occur?*

N/A

*Risks*

`ruby-install` runs a `brew upgrade` in the background if all of the dependencies/pre-requisites for ruby 2.7.1 are not already installed which could affect development environments. Will have to slack out tech-development prior to upgrading to let the team know.

For myself, I had to run the following post ruby 2.7.1 installation:

`brew services restart rabbitmq`
`brew postgresql-upgrade-database`

*Requested Reviewers*

@bcarr092 @dragoszt 
