### PR TITLE
Update ruby to 3.0.2 and rubocop-rspec to 2.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/porky_lib
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: circleci/ruby:3.0.2
 
     steps:
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.7.2'
+ruby '3.0.2'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
   specs:
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.502.0)
+    aws-partitions (1.503.0)
     aws-sdk-core (3.121.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -35,9 +35,9 @@ GEM
       simplecov
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     docile (1.4.0)
-    ffi (1.15.3)
+    ffi (1.15.4)
     jmespath (1.4.0)
     msgpack (1.4.2)
     parallel (1.21.0)
@@ -49,21 +49,21 @@ GEM
       ffi
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-collection_matchers (1.2.0)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.21.0)
@@ -80,9 +80,8 @@ GEM
     rubocop-performance (1.11.5)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rspec (2.4.0)
-      rubocop (~> 1.0)
-      rubocop-ast (>= 1.1.0)
+    rubocop-rspec (2.5.0)
+      rubocop (~> 1.19)
     rubocop_runner (2.2.0)
     ruby-progressbar (1.11.0)
     simplecov (0.21.2)
@@ -93,7 +92,7 @@ GEM
     simplecov_json_formatter (0.1.3)
     thor (1.1.0)
     timecop (0.9.4)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -122,7 +121,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.0.2p107
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when key ID is nil ' do
+    it 'raises FileServiceError when key ID is nil' do
       expect do
         file_service.write(plaintext_data, bucket_name, nil)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
@@ -221,7 +221,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileServiceHelper::FileServiceError)
     end
 
-    it 'raises FileServiceError when file is nil ' do
+    it 'raises FileServiceError when file is nil' do
       expect do
         file_service.write_file(nil, bucket_name, default_key_id)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
@@ -233,7 +233,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when key ID is nil ' do
+    it 'raises FileServiceError when key ID is nil' do
       expect do
         file_service.write_file(write_test_file(plaintext_data), bucket_name, nil)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
@@ -297,25 +297,25 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
     end
 
-    it 'raises FileServiceError when data is nil ' do
+    it 'raises FileServiceError when data is nil' do
       expect do
         file_service.write_data(nil, bucket_name, default_key_id)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when bucket name is nil ' do
+    it 'raises FileServiceError when bucket name is nil' do
       expect do
         file_service.write_data(plaintext_data, nil, default_key_id)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when key ID is nil ' do
+    it 'raises FileServiceError when key ID is nil' do
       expect do
         file_service.write_data(plaintext_data, bucket_name, nil)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when writing to bucket without permission ' do
+    it 'raises FileServiceError when writing to bucket without permission' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {
@@ -327,7 +327,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when writing to bucket that does not exist ' do
+    it 'raises FileServiceError when writing to bucket that does not exist' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {
@@ -399,7 +399,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when overwriting an existing file with nil file_key ' do
+    it 'raises FileServiceError when overwriting an existing file with nil file_key' do
       expect do
         file_service.overwrite_file(plaintext_data, nil, bucket_name, default_key_id)
       end.to raise_error(PorkyLib::FileService::FileServiceError)
@@ -411,7 +411,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when key ID is nil ' do
+    it 'raises FileServiceError when key ID is nil' do
       expect do
         file_service.overwrite_file(plaintext_data, default_file_key, bucket_name, nil)
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
@@ -464,7 +464,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileSizeTooLargeError)
     end
 
-    it 'raises FileServiceError if reading from bucket without permission ' do
+    it 'raises FileServiceError if reading from bucket without permission' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {
@@ -476,7 +476,7 @@ RSpec.describe PorkyLib::FileService, type: :request do
       end.to raise_exception(PorkyLib::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when bucket does not exist ' do
+    it 'raises FileServiceError when bucket does not exist' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {

--- a/spec/porky_lib/unencrypted/file_service_spec.rb
+++ b/spec/porky_lib/unencrypted/file_service_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
       end.to raise_exception(PorkyLib::Unencrypted::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when writing to bucket without permission ' do
+    it 'raises FileServiceError when writing to bucket without permission' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {
@@ -326,7 +326,7 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
       end.to raise_exception(PorkyLib::Unencrypted::FileService::FileSizeTooLargeError)
     end
 
-    it 'raises FileServiceError when reading bucket without permission ' do
+    it 'raises FileServiceError when reading bucket without permission' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {
@@ -338,7 +338,7 @@ RSpec.describe PorkyLib::Unencrypted::FileService, type: :request do
       end.to raise_exception(PorkyLib::Unencrypted::FileService::FileServiceError)
     end
 
-    it 'raises FileServiceError when bucket does not exist ' do
+    it 'raises FileServiceError when bucket does not exist' do
       Aws.config[:s3].delete(:stub_responses)
       Aws.config[:s3] = {
         stub_responses: {


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/19100

*Why?*

Dependabot failed to update rubocop-rspec due to existing tests violating new rules, so do it manually.  Also update ruby to 3.0.2.

*How?*

Explain the development-level approach you are using in this solution.

*Risks*

Explain the risks that are involved with making this change, if any.

*Requested Reviewers*

List the developers that should review this pull request.
