### PR TITLE
chore: group Dependabot minor+patch updates + set assignee [LEN-667]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,42 +5,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - dragoszt
+  open-pull-requests-limit: 20
   assignees:
-  - dragoszt
-  ignore:
-  - dependency-name: aws-sdk-s3
-    versions:
-    - 1.88.1
-    - 1.88.2
-    - 1.89.0
-    - 1.90.0
-    - 1.92.0
-    - 1.93.1
-  - dependency-name: rubocop
-    versions:
-    - 1.10.0
-    - 1.12.0
-    - 1.12.1
-    - 1.9.0
-  - dependency-name: codecov
-    versions:
-    - 0.5.0
-  - dependency-name: rubocop-performance
-    versions:
-    - 1.10.0
-  - dependency-name: timecop
-    versions:
-    - 0.9.2
-    - 0.9.3
-  - dependency-name: aws-sdk-kms
-    versions:
-    - 1.42.0
-  - dependency-name: rubocop-rspec
-    versions:
-    - 1.44.1
-  - dependency-name: msgpack
-    versions:
-    - 1.4.1
+  - TC-SJ-Yoon
+  # Collapse minor + patch gem bumps into one PR; majors stay individual (LEN-616).
+  groups:
+    minor-and-patch:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"


### PR DESCRIPTION
## What

Brings `porky_lib`'s Dependabot config in line with the four main apps (zetatango, roadrunner, wile_e, foghorn) that were done under LEN-616.

- **Group minor + patch** gem bumps into a single PR (`minor-and-patch` group, `patterns: "*"`); majors stay individual.
- **Assignee → `TC-SJ-Yoon`** (previously `dragoszt` as both reviewer and assignee).
- **`open-pull-requests-limit` 10 → 20** to match the standard.
- **Removed the stale per-dependency version ignores** — every pin (aws-sdk-s3 1.88–1.93, rubocop 1.9–1.12, codecov 0.5.0, timecop 0.9.2–0.9.3, etc.) targets long-superseded releases and is effectively a no-op today.

Bundler-only — no npm/registries block needed (porky_lib is a gem sourced from rubygems.org).

## Why

Matches the batching behaviour rolled out across the main apps so gem updates land as a few reviewable PRs instead of one-per-package, and routes review to the current maintainer. LEN-616 explicitly scoped only the four deployed apps; this extends the same fix to the shared `porky_lib` gem.

Fixes LEN-667
