### PR TITLE
feat: migrate off deprecated codecov gem to Codecov CLI + simplecov 1.x [LEN-669]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,16 @@ jobs:
               --out test_results/rspec.xml \
               --format progress
 
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            set -euo pipefail
+            curl -fsSLo codecov --retry 5 --retry-delay 2 https://cli.codecov.io/latest/linux/codecov
+            curl -fsSLo codecov.SHA256SUM --retry 5 --retry-delay 2 https://cli.codecov.io/latest/linux/codecov.SHA256SUM
+            sha256sum -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov upload-process --fail-on-error -t "${CODECOV_TOKEN}" -f coverage/coverage.xml
+
       - store_test_results:
           path: test_results
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ group :development, :test do
   gem 'bundler-audit'
   gem 'byebug'
   gem 'codacy-coverage'
-  gem 'codecov'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-collection_matchers'
@@ -26,5 +25,6 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'rubocop_runner'
   gem 'simplecov'
+  gem 'simplecov-cobertura' # For Codecov CLI compatibility
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,7 @@ GEM
       reline (>= 0.6.0)
     codacy-coverage (2.2.1)
       simplecov
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     ffi (1.17.3)
     io-console (0.8.2)
     jmespath (1.6.2)
@@ -106,12 +103,10 @@ GEM
       rubocop (~> 1.81)
     rubocop_runner (2.2.1)
     ruby-progressbar (1.13.0)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.1)
+    simplecov-cobertura (4.0.0)
+      rexml
+      simplecov (~> 1.0)
     thor (1.5.0)
     timecop (0.9.10)
     unicode-display_width (3.2.0)
@@ -126,7 +121,6 @@ DEPENDENCIES
   bundler-audit
   byebug
   codacy-coverage
-  codecov
   porky_lib!
   rake
   rspec
@@ -138,6 +132,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop_runner
   simplecov
+  simplecov-cobertura
   timecop
 
 RUBY VERSION

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        # simplecov 1.0 no longer counts spec files as covered code (LEN-669),
+        # so the measured line set shrank vs the old baseline that included
+        # them. Allow a small one-time drop so the migration doesn't hard-fail;
+        # master re-baselines to the accurate lib-only number on merge.
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,tree"
+  require_changes: no

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,19 +2,22 @@
 
 if ENV.fetch('COVERAGE', nil) || ENV.fetch('CI', nil)
   require 'simplecov'
+  require 'simplecov-cobertura'
   require 'codacy-coverage'
-  require 'codecov'
 
+  # Codecov ingests the Cobertura XML (coverage/coverage.xml) via its CLI in CI.
+  # The codecov Ruby gem was dropped because it pinned simplecov < 0.22, which
+  # blocked simplecov upgrades (LEN-669).
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
     [
-      SimpleCov::Formatter::Codecov,
+      SimpleCov::Formatter::CoberturaFormatter,
       SimpleCov::Formatter::HTMLFormatter,
       Codacy::Formatter
     ]
   )
 
   SimpleCov.start do
-    add_group 'LIB', %w[lib spec]
+    group 'LIB', %w[lib spec]
   end
 end
 


### PR DESCRIPTION
## What

Migrates porky_lib off the deprecated `codecov` Ruby gem (which pinned `simplecov (>= 0.15, < 0.22)` and blocked simplecov upgrades) to the **Codecov CLI**, and bumps **simplecov 0.21.2 → 1.0.1**.

This is the proper fix for the failure surfaced by Dependabot #649, where bumping simplecov could only be resolved by silently downgrading `codecov 0.6.0 → 0.2.12`, corrupting the coverage upload.

## Changes

- **Drop the `codecov` gem**; upload coverage via the Codecov CLI in CircleCI (curl + SHA256 verify + `upload-process`), using the same `CODECOV_TOKEN`. Matches the fleet convention (roadrunner/wile_e/zetatango/foghorn).
- **`simplecov-cobertura`** emits `coverage/coverage.xml` (`CoberturaFormatter`) for the CLI to ingest.
- **simplecov 0.21.2 → 1.0.1** (now unblocked); simplecov-cobertura 4.0.0.
- Fix the `SimpleCov.add_group` → `group` deprecation.
- Add **`codecov.yml`** (see note below).

## Coverage number: why it changes (and why it's correct)

simplecov 1.0 **no longer counts spec files** as covered code — the same thing the main apps do (roadrunner's `'rails'` profile filters `/spec/`). So the report goes from **13 files / 1203 lines / 99.83%** (which counted the specs themselves, ~100% executed, inflating the %) to the **accurate 8 lib files / 337 lines / 99.40%**.

The 2 uncovered lines are pre-existing (master already had 2 misses) and live in a **dead private method** `FileServiceHelper#a_path?` — it has no callers, so covering it would mean testing dead code. Left as-is.

`codecov.yml` sets a **1% project threshold** to absorb this one-time re-baseline so `codecov/project` doesn't hard-fail on the migration; master re-baselines to 99.40% on merge and future PRs compare fairly.

## Verified locally (Ruby 3.3.10, CI mode)

- `rspec` → **172 examples, 0 failures**
- `coverage/coverage.xml` → valid Cobertura XML
- `rubocop` → 19 files, **no offenses**
- `bundle-audit check` → **No vulnerabilities found**

## Follow-up (out of scope)

`codacy-coverage 2.2.1`'s `Codacy::Formatter` raises `NoMethodError: undefined method 'exists?' for File` (removed in Ruby 3.2+) on **every** run — caught and non-fatal, so Codacy coverage upload has been silently dead since the Ruby 3.3 bump. Worth a separate ticket to migrate or remove it.

Fixes [LEN-669](https://linear.app/purposeunlimited/issue/LEN-669/porky-lib-migrate-off-deprecated-codecov-gem-to-unblock-simplecov)
