### PR TITLE
fix: retain Tempfile reference in file_service_spec to stop GC race [LEN-671]

### DIFF
--- a/spec/porky_lib/file_service_spec.rb
+++ b/spec/porky_lib/file_service_spec.rb
@@ -141,7 +141,11 @@ RSpec.describe PorkyLib::FileService, type: :request do
     end
 
     it 'writes the right content to S3 if path is used' do
-      path = write_test_file(plaintext_data).path
+      # Keep the Tempfile referenced for the duration of the example; if only its
+      # path is retained, GC can finalize and unlink the file before write_file
+      # reads it (flaky under GC pressure, e.g. on CI).
+      file = write_test_file(plaintext_data)
+      path = file.path
 
       test_file_content(plaintext_data) do
         file_service.write_file(path, bucket_name, default_key_id)
@@ -155,7 +159,10 @@ RSpec.describe PorkyLib::FileService, type: :request do
     end
 
     it 'raises FileServiceError when file cannot be read (no permission)' do
-      path = write_test_file(plaintext_data).path
+      # Retain the Tempfile so the error asserted below comes from the chmod
+      # (no read permission), not from GC unlinking the file out from under us.
+      file = write_test_file(plaintext_data)
+      path = file.path
 
       expect do
         File.chmod(0o000, path)


### PR DESCRIPTION
## What

Fixes the intermittent **master** `build` failure on rspec:

```
rspec ./spec/porky_lib/file_service_spec.rb:143
  # PorkyLib::FileService#write_file writes the right content to S3 if path is used
```
([failing run](https://app.circleci.com/pipelines/github/Zetatango/porky_lib/827/workflows/e5085386-a6ce-493b-90bf-14d285231d55/jobs/1334))

## Root cause — Tempfile GC race (spec bug, not a dependency issue)

Line 144 kept only the path and dropped the Tempfile object:
```ruby
path = write_test_file(plaintext_data).path
```
`write_test_file` returns a `Tempfile`. Unreferenced, its finalizer **unlinks the temp file** at the next GC; if that beats `write_file`'s read, `File.file?(path)` is false → `FileServiceError` → the example fails. The "if file object is used" sibling passes only because it keeps the Tempfile in a variable.

Deterministic repro: `GC_STRESS=1` fails the example **every** time; normal timing hides it (green on dev machines, flaky on CI under memory pressure).

Not caused by the recent merges — `file_service_spec.rb` was last touched in #644; #648/#650 didn't modify it, they just shifted GC timing enough to surface the latent bug.

## Fix

Retain the Tempfile in a local for the whole example, at **line 144** and the same latent pattern at **line 158** (masked there because a GC-deleted file raises the same error that test asserts — i.e. it could pass for the wrong reason).

## Verified

- Full suite under `GC_STRESS=1`: **172 examples, 0 failures** (previously failed every run)
- `rubocop`: no offenses

Fixes [LEN-671](https://linear.app/purposeunlimited/issue/LEN-671/porky-lib-master-ci-red-flaky-tempfile-gc-race-in-file-service-spec)
