### PR TITLE
chore: coverage-tooling cleanup — drop Codacy, remove dead code [LEN-670]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :development, :test do
   gem 'bundler'
   gem 'bundler-audit'
   gem 'byebug'
-  gem 'codacy-coverage'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-collection_matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,6 @@ GEM
       thor (~> 1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    codacy-coverage (2.2.1)
-      simplecov
     diff-lcs (1.6.2)
     ffi (1.17.3)
     io-console (0.8.2)
@@ -121,7 +119,6 @@ DEPENDENCIES
   bundler
   bundler-audit
   byebug
-  codacy-coverage
   porky_lib!
   rake
   rspec

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,11 +6,10 @@ coverage:
     project:
       default:
         target: auto
-        # simplecov 1.0 no longer counts spec files as covered code (LEN-669),
-        # so the measured line set shrank vs the old baseline that included
-        # them. Allow a small one-time drop so the migration doesn't hard-fail;
-        # master re-baselines to the accurate lib-only number on merge.
-        threshold: 1%
+        # Strict: lib coverage is 100%, so any drop should fail (LEN-670). The
+        # one-time simplecov-1.0 re-baseline that needed a temporary threshold
+        # has landed on master.
+        threshold: 0%
     patch:
       default:
         target: auto

--- a/lib/porky_lib/file_service_helper.rb
+++ b/lib/porky_lib/file_service_helper.rb
@@ -70,12 +70,6 @@ module PorkyLib::FileServiceHelper
     !file_or_content.is_a?(String)
   end
 
-  def a_path?(content_or_path)
-    return false if contain_null_byte?(content_or_path)
-
-    File.file?(content_or_path)
-  end
-
   def contain_null_byte?(data)
     null_byte = (+"\u0000").force_encoding("ASCII-8BIT")
     data = (+data).force_encoding("ASCII-8BIT")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@
 if ENV.fetch('COVERAGE', nil) || ENV.fetch('CI', nil)
   require 'simplecov'
   require 'simplecov-cobertura'
-  require 'codacy-coverage'
 
   # Codecov ingests the Cobertura XML (coverage/coverage.xml) via its CLI in CI.
   # The codecov Ruby gem was dropped because it pinned simplecov < 0.22, which
@@ -11,8 +10,7 @@ if ENV.fetch('COVERAGE', nil) || ENV.fetch('CI', nil)
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
     [
       SimpleCov::Formatter::CoberturaFormatter,
-      SimpleCov::Formatter::HTMLFormatter,
-      Codacy::Formatter
+      SimpleCov::Formatter::HTMLFormatter
     ]
   )
 


### PR DESCRIPTION
## What

Coverage-tooling cleanup, follow-up to the codecov-gem migration (LEN-669). Three items:

### 1. Drop the dead Codacy coverage integration
`codacy-coverage 2.2.1`'s `Codacy::Formatter` raised `NoMethodError: undefined method 'exists?' for File` (removed in Ruby 3.2+) on **every** run since the Ruby 3.3 bump — SimpleCov caught it, so its coverage upload has been silently broken and only spewed an error. Removed the gem + the formatter.
_(The "Codacy Static Code Analysis" GitHub check is a separate integration — unaffected.)_

### 2. Delete dead method `FileServiceHelper#a_path?`
No callers anywhere in `lib/` or the four consuming apps (verified in LEN-669). It held the repo's only 2 uncovered lib lines. Removing it → **true 100% coverage**.

### 3. Tighten `codecov.yml` project threshold
`1% → 0%` now that the one-time simplecov-1.0 re-baseline has landed on master. With 100% coverage, any drop now fails the project check.

## Verified locally

- `rspec` → **172 examples, 0 failures**, **line coverage 100.0% (334/334)** (was 99.4%)
- No Codacy formatter error in the run
- `coverage/coverage.xml` (Cobertura) still emitted for the Codecov CLI
- `rubocop` → 19 files, no offenses · `bundle-audit` → clean

Fixes LEN-670
